### PR TITLE
fix: mobile task input keyboard should not dismiss on mobile

### DIFF
--- a/apps/webapp/src/components/atoms/AddTaskInput.tsx
+++ b/apps/webapp/src/components/atoms/AddTaskInput.tsx
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
 import { toast } from '@/components/ui/use-toast';
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import type { DayOfWeek } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
@@ -26,6 +27,7 @@ export const AddTaskInput = ({
   const [newGoalTitle, setNewGoalTitle] = useState('');
   const [isVisible, setIsVisible] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { isTouchDevice } = useDeviceScreenInfo();
 
   // Handle successful task creation
   const handleSubmit = async () => {
@@ -97,9 +99,12 @@ export const AddTaskInput = ({
           onEscape={handleEscape}
           onFocus={() => setIsVisible(true)}
           onBlur={() => {
-            // Only hide if empty and not actively being used
+            // On touch devices, don't hide the input on blur to keep keyboard open
+            // On desktop, only hide if empty and not actively being used
+            if (isTouchDevice) {
+              return;
+            }
             if (!newGoalTitle) {
-              // Small delay to allow for click events to process
               setTimeout(() => setIsVisible(false), 100);
             }
           }}

--- a/apps/webapp/src/components/organisms/DailyGoalGroup.tsx
+++ b/apps/webapp/src/components/organisms/DailyGoalGroup.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useGoalActionsContext } from '@/contexts/GoalActionsContext';
 import { GoalProvider } from '@/contexts/GoalContext';
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import type { DayOfWeekType } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
@@ -35,6 +36,7 @@ export const DailyGoalGroup = ({
   const [newGoalTitle, setNewGoalTitle] = useState('');
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
+  const { isTouchDevice } = useDeviceScreenInfo();
 
   const unsortedDailyGoals = weeklyGoal.children.filter(
     (dailyGoal) => dailyGoal.state?.daily?.dayOfWeek === dayOfWeek
@@ -151,6 +153,9 @@ export const DailyGoalGroup = ({
                   onEscape={handleEscape}
                   onFocus={() => setIsInputFocused(true)}
                   onBlur={() => {
+                    if (isTouchDevice) {
+                      return;
+                    }
                     if (!newGoalTitle) {
                       setIsInputFocused(false);
                       setIsHovering(false);

--- a/apps/webapp/src/components/organisms/DailyGoalList.tsx
+++ b/apps/webapp/src/components/organisms/DailyGoalList.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/molecules/goal-details-popover';
 import { Spinner } from '@/components/ui/spinner';
 import { GoalProvider } from '@/contexts/GoalContext';
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import { useWeek } from '@/hooks/useWeek';
 import type { DayOfWeekType } from '@/lib/constants';
 import { cn } from '@/lib/utils';
@@ -61,6 +62,7 @@ export const DailyGoalListContainer = ({
   const [newGoalTitle, setNewGoalTitle] = useState('');
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
+  const { isTouchDevice } = useDeviceScreenInfo();
 
   const handleSubmit = async () => {
     if (!newGoalTitle.trim()) return;
@@ -99,6 +101,9 @@ export const DailyGoalListContainer = ({
               onEscape={handleEscape}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => {
+                if (isTouchDevice) {
+                  return;
+                }
                 if (!newGoalTitle) {
                   setIsInputFocused(false);
                   setIsHovering(false);

--- a/apps/webapp/src/components/organisms/DailyGoalListContainer.tsx
+++ b/apps/webapp/src/components/organisms/DailyGoalListContainer.tsx
@@ -5,6 +5,7 @@ import { DailyGoalList } from './DailyGoalList';
 import { CreateGoalInput } from '../atoms/CreateGoalInput';
 
 import { Spinner } from '@/components/ui/spinner';
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import { cn } from '@/lib/utils';
 
 export interface DailyGoalListContainerProps {
@@ -27,6 +28,7 @@ export const DailyGoalListContainer = ({
   const [newGoalTitle, setNewGoalTitle] = useState('');
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
+  const { isTouchDevice } = useDeviceScreenInfo();
 
   const handleSubmit = async () => {
     if (!newGoalTitle.trim()) return;
@@ -64,6 +66,9 @@ export const DailyGoalListContainer = ({
               onEscape={handleEscape}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => {
+                if (isTouchDevice) {
+                  return;
+                }
                 if (!newGoalTitle) {
                   setIsInputFocused(false);
                   setIsHovering(false);

--- a/apps/webapp/src/components/organisms/WeekCardWeeklyGoals.tsx
+++ b/apps/webapp/src/components/organisms/WeekCardWeeklyGoals.tsx
@@ -30,6 +30,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { toast } from '@/components/ui/use-toast';
 import { GoalProvider, useGoalContext } from '@/contexts/GoalContext';
 import { useFireGoals } from '@/contexts/GoalStatusContext';
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import { type GoalWithOptimisticStatus, useWeek } from '@/hooks/useWeek';
 import { getDueDateStyle } from '@/lib/date/getDueDateStyle';
 import { cn } from '@/lib/utils';
@@ -239,6 +240,7 @@ const WeeklyGoalGroup = ({
   const [newGoalTitle, setNewGoalTitle] = useState('');
   const [previousTitle, setPreviousTitle] = useState(''); // Store previous title for error recovery
   const { createWeeklyGoalOptimistic, year, quarter, weekNumber } = useWeek();
+  const { isTouchDevice } = useDeviceScreenInfo();
 
   const handleSubmit = async () => {
     const trimmedTitle = newGoalTitle.trim();
@@ -315,6 +317,9 @@ const WeeklyGoalGroup = ({
             onEscape={handleEscape}
             onFocus={() => setIsCreating(true)}
             onBlur={() => {
+              if (isTouchDevice) {
+                return;
+              }
               if (!newGoalTitle) {
                 setIsCreating(false);
                 setIsHovering(false);


### PR DESCRIPTION
## Summary

- Prevent keyboard dismissal on touch devices when creating tasks
- On mobile (touch devices), the `onBlur` handler no longer hides the input or collapses the task creation UI, keeping the keyboard open for continuous input

## Changes

- `AddTaskInput`: Skip blur handler on touch devices
- `DailyGoalGroup`: Skip blur handler on touch devices
- `DailyGoalList` / `DailyGoalListContainer`: Skip blur handler on touch devices
- `WeekCardWeeklyGoals` (`WeeklyGoalGroup`): Skip blur handler on touch devices
- Uses existing `isTouchDevice` from `useDeviceScreenInfo` hook for device detection

## Testing

- `pnpm typecheck` ✅
- `pnpm test` ✅

Closes backlog item: ps7ajfymdsxv3dq4g3a0b95475854w1k