### PR TITLE
feat(focus): add Quarterly Goals section to focused view

### DIFF
--- a/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
@@ -24,6 +24,7 @@ import { useCallback, useEffect, useState } from 'react';
 import {
   FocusedAdhocGoalsSection,
   FocusedDailyGoalsSection,
+  FocusedQuarterlyGoalsSection,
   FocusedUrgentSection,
   FocusedWeeklyGoalsSection,
 } from '@/components/organisms/focus/focused-view';
@@ -265,6 +266,11 @@ export function FocusModeFocusedView() {
             <FocusedUrgentSection
               goals={focusedViewData.urgent}
               onToggleComplete={handleUrgentCompleteChange}
+            />
+
+            <FocusedQuarterlyGoalsSection
+              goals={focusedViewData.quarterlyGoals}
+              onToggleComplete={handleNormalGoalCompleteChange}
             />
 
             <FocusedWeeklyGoalsSection

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
-import { Loader2 } from 'lucide-react';
+import { ListTodo, Loader2 } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -16,7 +16,10 @@ export function FocusedAdhocGoalsSection({
   onToggleComplete,
 }: FocusedAdhocGoalsSectionProps) {
   return (
-    <FocusedGoalSection title="Tasks">
+    <FocusedGoalSection
+      title="Tasks"
+      icon={<ListTodo className="h-3.5 w-3.5 text-muted-foreground" />}
+    >
       <div className="px-4 py-2">
         {goals === undefined ? (
           <div className="flex items-center justify-center h-16">

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedDailyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedDailyGoalsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
+import { Sun } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -19,7 +20,11 @@ export function FocusedDailyGoalsSection({
   const incompleteCount = goals.filter((g) => !g.isComplete).length;
 
   return (
-    <FocusedGoalSection title="Daily Goals" count={incompleteCount}>
+    <FocusedGoalSection
+      title="Daily Goals"
+      count={incompleteCount}
+      icon={<Sun className="h-3.5 w-3.5 text-muted-foreground" />}
+    >
       <div className="px-4 py-2">
         <ul className="space-y-1">
           {goals.map((goal) => (

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
@@ -19,6 +19,7 @@ interface FocusedGoalListItemProps {
   incompleteClassName?: string;
   /** Nesting depth for visual indentation (0 = root) */
   indentLevel?: number;
+  leadingIndicator?: React.ReactNode;
 }
 
 export function FocusedGoalListItem({
@@ -32,6 +33,7 @@ export function FocusedGoalListItem({
   onToggleComplete,
   incompleteClassName,
   indentLevel = 0,
+  leadingIndicator,
 }: FocusedGoalListItemProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
@@ -46,6 +48,7 @@ export function FocusedGoalListItem({
           onCheckedChange={(checked) => onToggleComplete(goalId, Boolean(checked))}
           className="flex-shrink-0"
         />
+        {leadingIndicator && <span className="flex-shrink-0">{leadingIndicator}</span>}
         <button
           type="button"
           onClick={() => setPopoverOpen(true)}

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
@@ -5,6 +5,7 @@ interface FocusedGoalSectionProps {
   count?: number;
   countColorClass?: string;
   countDotColorClass?: string;
+  icon?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -13,11 +14,13 @@ export function FocusedGoalSection({
   count,
   countColorClass = 'text-muted-foreground',
   countDotColorClass = 'bg-muted-foreground',
+  icon,
   children,
 }: FocusedGoalSectionProps) {
   return (
     <div>
       <div className="flex items-center gap-2 px-4 py-3 border-b-2 border-border">
+        {icon && <span className="flex-shrink-0 text-muted-foreground">{icon}</span>}
         <h3 className="text-xs font-bold uppercase tracking-wider text-foreground">{title}</h3>
         {count !== undefined && count > 0 && (
           <span className="flex items-center gap-1">

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
+
+import { FocusedGoalListItem } from './FocusedGoalListItem';
+import { FocusedGoalSection } from './FocusedGoalSection';
+
+interface FocusedQuarterlyGoalsSectionProps {
+  goals: FocusedGoalItem[];
+  onToggleComplete: (goalId: FocusedGoalItem['_id'], isComplete: boolean) => void;
+}
+
+export function FocusedQuarterlyGoalsSection({
+  goals,
+  onToggleComplete,
+}: FocusedQuarterlyGoalsSectionProps) {
+  if (goals.length === 0) return null;
+
+  return (
+    <FocusedGoalSection title="Quarterly Goals" count={goals.length}>
+      <div className="px-4 py-2">
+        <ul className="space-y-1">
+          {goals.map((goal) => (
+            <FocusedGoalListItem
+              key={goal._id}
+              goalId={goal._id}
+              title={goal.title}
+              isComplete={goal.isComplete}
+              isAdhoc={false}
+              year={goal.year}
+              quarter={goal.quarter as 1 | 2 | 3 | 4}
+              weekNumber={goal.weekNumber}
+              onToggleComplete={onToggleComplete}
+            />
+          ))}
+        </ul>
+      </div>
+    </FocusedGoalSection>
+  );
+}

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
+import { Pin, Star, Target } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -17,22 +18,34 @@ export function FocusedQuarterlyGoalsSection({
   if (goals.length === 0) return null;
 
   return (
-    <FocusedGoalSection title="Quarterly Goals" count={goals.length}>
+    <FocusedGoalSection
+      title="Quarterly Goals"
+      count={goals.length}
+      icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
+    >
       <div className="px-4 py-2">
         <ul className="space-y-1">
-          {goals.map((goal) => (
-            <FocusedGoalListItem
-              key={goal._id}
-              goalId={goal._id}
-              title={goal.title}
-              isComplete={goal.isComplete}
-              isAdhoc={false}
-              year={goal.year}
-              quarter={goal.quarter as 1 | 2 | 3 | 4}
-              weekNumber={goal.weekNumber}
-              onToggleComplete={onToggleComplete}
-            />
-          ))}
+          {goals.map((goal) => {
+            const indicator = goal.isStarred ? (
+              <Star className="h-3 w-3 fill-amber-400 text-amber-500 dark:text-amber-400" />
+            ) : goal.isPinned ? (
+              <Pin className="h-3 w-3 fill-blue-500 text-blue-500 dark:text-blue-400" />
+            ) : null;
+            return (
+              <FocusedGoalListItem
+                key={goal._id}
+                goalId={goal._id}
+                title={goal.title}
+                isComplete={goal.isComplete}
+                isAdhoc={false}
+                year={goal.year}
+                quarter={goal.quarter as 1 | 2 | 3 | 4}
+                weekNumber={goal.weekNumber}
+                onToggleComplete={onToggleComplete}
+                leadingIndicator={indicator}
+              />
+            );
+          })}
         </ul>
       </div>
     </FocusedGoalSection>

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
+import { Flame } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -21,6 +22,7 @@ export function FocusedUrgentSection({ goals, onToggleComplete }: FocusedUrgentS
       count={incompleteCount}
       countColorClass="text-red-400"
       countDotColorClass="bg-red-400"
+      icon={<Flame className="h-3.5 w-3.5 text-red-500 dark:text-red-400" />}
     >
       <div className="px-4 py-2">
         <ul className="space-y-1">

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedWeeklyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedWeeklyGoalsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
+import { CalendarRange } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -19,7 +20,11 @@ export function FocusedWeeklyGoalsSection({
   const incompleteCount = goals.filter((g) => !g.isComplete).length;
 
   return (
-    <FocusedGoalSection title="Weekly Goals" count={incompleteCount}>
+    <FocusedGoalSection
+      title="Weekly Goals"
+      count={incompleteCount}
+      icon={<CalendarRange className="h-3.5 w-3.5 text-muted-foreground" />}
+    >
       <div className="px-4 py-2">
         <ul className="space-y-1">
           {goals.map((goal) => (

--- a/apps/webapp/src/components/organisms/focus/focused-view/index.ts
+++ b/apps/webapp/src/components/organisms/focus/focused-view/index.ts
@@ -2,5 +2,6 @@ export { FocusedAdhocGoalsSection } from './FocusedAdhocGoalsSection';
 export { FocusedDailyGoalsSection } from './FocusedDailyGoalsSection';
 export { FocusedGoalListItem } from './FocusedGoalListItem';
 export { FocusedGoalSection } from './FocusedGoalSection';
+export { FocusedQuarterlyGoalsSection } from './FocusedQuarterlyGoalsSection';
 export { FocusedUrgentSection } from './FocusedUrgentSection';
 export { FocusedWeeklyGoalsSection } from './FocusedWeeklyGoalsSection';

--- a/services/backend/convex/bff/focus.ts
+++ b/services/backend/convex/bff/focus.ts
@@ -23,6 +23,8 @@ export type FocusedGoalItem = {
   depth: number;
   indentLevel: number;
   breadcrumb: BreadcrumbSegment[];
+  isStarred?: boolean;
+  isPinned?: boolean;
 };
 
 export type FocusedViewData = {
@@ -48,7 +50,7 @@ export const getFocusedViewData = query({
 
     const [urgent, quarterlyGoals, weeklyGoals, dailyGoals, adhocTasks] = await Promise.all([
       getUrgentGoals(ctx, { userId, year, quarter, weekNumber, dayOfWeek }),
-      getQuarterlyGoals(ctx, { userId, year, quarter }),
+      getQuarterlyGoals(ctx, { userId, year, quarter, weekNumber }),
       getWeeklyGoals(ctx, { userId, year, quarter, weekNumber }),
       getDailyGoalsForDay(ctx, { userId, year, quarter, weekNumber, dayOfWeek }),
       getAdhocTasksFlattened(ctx, { userId, year, weekNumber }),
@@ -66,9 +68,10 @@ async function getQuarterlyGoals(
     userId: Id<'users'>;
     year: number;
     quarter: number;
+    weekNumber: number;
   }
 ): Promise<FocusedGoalItem[]> {
-  const { userId, year, quarter } = args;
+  const { userId, year, quarter, weekNumber } = args;
 
   const goals = await ctx.db
     .query('goals')
@@ -77,21 +80,45 @@ async function getQuarterlyGoals(
     )
     .collect();
 
+  const weekStates = await ctx.db
+    .query('goalStateByWeek')
+    .withIndex('by_user_and_year_and_quarter_and_week', (q) =>
+      q.eq('userId', userId).eq('year', year).eq('quarter', quarter).eq('weekNumber', weekNumber)
+    )
+    .collect();
+
+  const stateByGoalId = new Map(weekStates.map((s) => [s.goalId.toString(), s]));
+
   return goals
     .filter((g) => g.depth === 0 && !g.adhoc && !g.isBacklog && !g.isComplete)
-    .sort((a, b) => a._creationTime - b._creationTime)
-    .map((g) => ({
-      _id: g._id,
-      title: g.title,
-      isComplete: g.isComplete ?? false,
-      isAdhoc: false,
-      year: g.year,
-      quarter: g.quarter,
-      weekNumber: undefined,
-      depth: 0,
-      indentLevel: 0,
-      breadcrumb: [],
-    }));
+    .sort((a, b) => {
+      const aState = stateByGoalId.get(a._id.toString());
+      const bState = stateByGoalId.get(b._id.toString());
+      const aStar = aState?.isStarred ? 1 : 0;
+      const bStar = bState?.isStarred ? 1 : 0;
+      if (aStar !== bStar) return bStar - aStar;
+      const aPin = aState?.isPinned ? 1 : 0;
+      const bPin = bState?.isPinned ? 1 : 0;
+      if (aPin !== bPin) return bPin - aPin;
+      return a._creationTime - b._creationTime;
+    })
+    .map((g) => {
+      const state = stateByGoalId.get(g._id.toString());
+      return {
+        _id: g._id,
+        title: g.title,
+        isComplete: g.isComplete ?? false,
+        isAdhoc: false,
+        year: g.year,
+        quarter: g.quarter,
+        weekNumber: undefined,
+        depth: 0,
+        indentLevel: 0,
+        breadcrumb: [],
+        isStarred: state?.isStarred ?? false,
+        isPinned: state?.isPinned ?? false,
+      };
+    });
 }
 
 // ── Urgent Goals ──────────────────────────────────────────────────────────────

--- a/services/backend/convex/bff/focus.ts
+++ b/services/backend/convex/bff/focus.ts
@@ -27,6 +27,7 @@ export type FocusedGoalItem = {
 
 export type FocusedViewData = {
   urgent: FocusedGoalItem[];
+  quarterlyGoals: FocusedGoalItem[];
   weeklyGoals: FocusedGoalItem[];
   dailyGoals: FocusedGoalItem[];
   adhocTasks: FocusedGoalItem[];
@@ -45,16 +46,53 @@ export const getFocusedViewData = query({
     const user = await requireLogin(ctx, sessionId);
     const userId = user._id;
 
-    const [urgent, weeklyGoals, dailyGoals, adhocTasks] = await Promise.all([
+    const [urgent, quarterlyGoals, weeklyGoals, dailyGoals, adhocTasks] = await Promise.all([
       getUrgentGoals(ctx, { userId, year, quarter, weekNumber, dayOfWeek }),
+      getQuarterlyGoals(ctx, { userId, year, quarter }),
       getWeeklyGoals(ctx, { userId, year, quarter, weekNumber }),
       getDailyGoalsForDay(ctx, { userId, year, quarter, weekNumber, dayOfWeek }),
       getAdhocTasksFlattened(ctx, { userId, year, weekNumber }),
     ]);
 
-    return { urgent, weeklyGoals, dailyGoals, adhocTasks };
+    return { urgent, quarterlyGoals, weeklyGoals, dailyGoals, adhocTasks };
   },
 });
+
+// ── Quarterly Goals ───────────────────────────────────────────────────────────
+
+async function getQuarterlyGoals(
+  ctx: QueryCtx,
+  args: {
+    userId: Id<'users'>;
+    year: number;
+    quarter: number;
+  }
+): Promise<FocusedGoalItem[]> {
+  const { userId, year, quarter } = args;
+
+  const goals = await ctx.db
+    .query('goals')
+    .withIndex('by_user_and_year_and_quarter', (q) =>
+      q.eq('userId', userId).eq('year', year).eq('quarter', quarter)
+    )
+    .collect();
+
+  return goals
+    .filter((g) => g.depth === 0 && !g.adhoc && !g.isBacklog && !g.isComplete)
+    .sort((a, b) => a._creationTime - b._creationTime)
+    .map((g) => ({
+      _id: g._id,
+      title: g.title,
+      isComplete: g.isComplete ?? false,
+      isAdhoc: false,
+      year: g.year,
+      quarter: g.quarter,
+      weekNumber: undefined,
+      depth: 0,
+      indentLevel: 0,
+      breadcrumb: [],
+    }));
+}
 
 // ── Urgent Goals ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Adds a Quarterly Goals section to the FocusModeFocusedView right panel, positioned below Urgent and above Weekly Goals. Clicking a goal opens the existing StandaloneGoalModal.

## Changes
- Extended FocusedViewData with quarterlyGoals via single indexed query in bff/focus.ts.
- Added FocusedQuarterlyGoalsSection mirroring existing section conventions.
- Wired into FocusModeFocusedView with existing handleNormalGoalCompleteChange.

## Verification
- pnpm typecheck passes
- pnpm test passes (38 backend + 87 webapp tests, 0 failures)