### PR TITLE
fix(scratchpad): stop New dialog buttons overflowing

### DIFF
--- a/apps/webapp/src/components/organisms/focus/ScratchpadNewDialog.tsx
+++ b/apps/webapp/src/components/organisms/focus/ScratchpadNewDialog.tsx
@@ -50,7 +50,7 @@ export function ScratchpadNewDialog({
             onClick={handleClearScratchpad}
           >
             <FileX className="mr-3 h-4 w-4 text-muted-foreground" />
-            <div className="flex flex-col items-start">
+            <div className="flex flex-col items-start text-left min-w-0 whitespace-normal">
               <span className="font-medium text-sm">Clear Scratchpad</span>
               <span className="text-xs text-muted-foreground">
                 Archive current content and start fresh
@@ -64,7 +64,7 @@ export function ScratchpadNewDialog({
             disabled={!hasCompletedItems}
           >
             <Eraser className="mr-3 h-4 w-4 text-muted-foreground" />
-            <div className="flex flex-col items-start">
+            <div className="flex flex-col items-start text-left min-w-0 whitespace-normal">
               <span className="font-medium text-sm">Remove Completed Items</span>
               <span className="text-xs text-muted-foreground">
                 Remove checked items from the scratchpad


### PR DESCRIPTION
## Root cause
The ShadCN `Button` base class includes `whitespace-nowrap`, which prevents the two-line label text inside each action button from wrapping. Combined with no `min-w-0` on the flex child, the long descriptions ('Archive current content and start fresh' / 'Remove checked items from the scratchpad') push the button content past the dialog edge.

## Fix
Added `text-left min-w-0 whitespace-normal` to the inner label `<div>` on both action buttons in `ScratchpadNewDialog.tsx`:
- `min-w-0`: lets the flex item shrink below its intrinsic content width so wrapping can occur
- `whitespace-normal`: overrides the inherited `whitespace-nowrap`
- `text-left`: keeps wrapped lines left-aligned

No other files were touched. No logic, handler, icon, copy, or variant changes.

## How to verify
1. Open the scratchpad and click 'New Scratchpad'
2. The dialog buttons ('Clear Scratchpad' and 'Remove Completed Items') should now display their descriptions without overflowing the dialog boundaries
3. Run `pnpm typecheck && pnpm test` — both pass