### PR TITLE
fix(focus): add iOS safe-area padding to add-task input

### DIFF
--- a/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
@@ -289,7 +289,7 @@ export function FocusModeFocusedView() {
             />
 
             {/* Inline add task */}
-            <div className="px-4 py-3">
+            <div className="px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))]">
               <div className="flex items-center gap-2 border-t border-border pt-3">
                 <Plus className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
                 <Input


### PR DESCRIPTION
## Root cause
On iOS standalone/PWA the Siri/home indicator bar overlaps the inline 'Add a task' input at the bottom of the Today's Tasks panel because the container has no bottom safe-area padding.

## Fix
Added `pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))]` to the inline add-task wrapper `<div>` in `FocusModeFocusedView.tsx`.

- `calc(0.75rem + env(safe-area-inset-bottom, 0px))` preserves the existing `py-3` (0.75rem) bottom padding and stacks the device safe-area inset on top
- On desktop/non-iOS the inset resolves to 0px so layout is visually unchanged
- Follows the same pattern already used in `GoalDetailsPopoverView.tsx` and `GoalEditPopover.tsx`

No other files were touched. No logic, handler, or scroll/overflow changes.

## How to verify
1. On an iPhone (PWA/standalone mode), open the app in Focus mode
2. The 'Add a task' input should now sit above the Siri/home indicator bar, not overlapping it
3. On desktop, layout should look identical to before
4. Run `pnpm typecheck && pnpm test` — both pass