### PR TITLE
fix(dark-mode): add dark text variants to editor and UI components

### DIFF
--- a/apps/webapp/src/app/docs/installation/page.tsx
+++ b/apps/webapp/src/app/docs/installation/page.tsx
@@ -90,7 +90,7 @@ export default function InstallationGuidePage() {
                     <Globe className="h-4 w-4 text-blue-600" />
                     Step 1: Visit the Website
                   </h3>
-                  <p className="text-sm text-slate-600 mb-2">
+                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-2">
                     Open Safari and navigate to{' '}
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">
                       goals.duskfare.com
@@ -157,7 +157,7 @@ export default function InstallationGuidePage() {
                     <Download className="h-4 w-4 text-indigo-600" />
                     Step 1: Install Raycast
                   </h3>
-                  <p className="text-sm text-slate-600 mb-2">
+                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-2">
                     If you don't already have Raycast installed:
                   </p>
                   <DocList>
@@ -252,7 +252,7 @@ export default function InstallationGuidePage() {
                     <Globe className="h-4 w-4 text-blue-600" />
                     Step 1: Visit the Website
                   </h3>
-                  <p className="text-sm text-slate-600 mb-2">
+                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-2">
                     Open Safari on your iOS device and navigate to{' '}
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">
                       goals.duskfare.com

--- a/apps/webapp/src/components/molecules/day-of-week/containers/PastDaysContainer.tsx
+++ b/apps/webapp/src/components/molecules/day-of-week/containers/PastDaysContainer.tsx
@@ -42,8 +42,8 @@ export const PastDaysContainer = ({
       <CollapsibleMinimalTrigger>
         <div className="flex justify-between w-full items-center">
           <span className="font-medium">Past Days</span>
-          <div className="flex items-center text-gray-600 text-sm whitespace-nowrap ml-2">
-            <Check className="w-3.5 h-3.5 mr-1 text-gray-400" />
+          <div className="flex items-center text-gray-600 dark:text-gray-400 text-sm whitespace-nowrap ml-2">
+            <Check className="w-3.5 h-3.5 mr-1 text-gray-400 dark:text-gray-500" />
             <span>
               {completedTasks}/{totalTasks}
             </span>

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
@@ -196,7 +196,7 @@ export const GoalPopoverTrigger = forwardRef<HTMLButtonElement, GoalPopoverTrigg
       title,
       variant = 'ghost',
       className = 'p-0 h-auto hover:bg-transparent font-normal justify-start text-left flex-1 focus-visible:ring-0 min-w-0 w-full mb-1 normal-case tracking-normal',
-      titleClassName = 'text-gray-600',
+      titleClassName = 'text-gray-600 dark:text-gray-400',
       ...props
     },
     ref

--- a/apps/webapp/src/components/molecules/quarter/QuarterActionMenu.tsx
+++ b/apps/webapp/src/components/molecules/quarter/QuarterActionMenu.tsx
@@ -150,7 +150,9 @@ export const QuarterActionMenu = React.memo(
                       <History className="mr-2 h-4 w-4" />
                       <div className="flex flex-col w-full items-center">
                         <span>Pull Incomplete</span>
-                        <span className="text-gray-500 text-xs">from previous quarter</span>
+                        <span className="text-gray-500 dark:text-gray-400 text-xs">
+                          from previous quarter
+                        </span>
                       </div>
                     </DropdownMenuItem>
                   </div>

--- a/apps/webapp/src/components/organisms/WeekCardPreviewDialog.tsx
+++ b/apps/webapp/src/components/organisms/WeekCardPreviewDialog.tsx
@@ -302,7 +302,7 @@ export const WeekCardPreviewDialog = ({
                 <span className="block">
                   There are no incomplete tasks from the last non-empty week to move to this week.
                 </span>
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
                   <History className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <span className="block">
                     All tasks from the last non-empty week are complete!

--- a/apps/webapp/src/components/ui/rich-text-editor.tsx
+++ b/apps/webapp/src/components/ui/rich-text-editor.tsx
@@ -401,7 +401,7 @@ export function RichTextEditor({
     editorProps: {
       attributes: {
         class: cn(
-          'prose prose-sm text-sm max-w-none focus:outline-none min-h-[150px] h-full p-3 rounded-md border break-words [word-break:break-word]',
+          'prose prose-sm dark:prose-invert text-sm max-w-none focus:outline-none min-h-[150px] h-full p-3 rounded-md border break-words [word-break:break-word]',
           styles.prose,
           className
         ),


### PR DESCRIPTION
## Summary
Fix dark mode text visibility across the codebase by adding appropriate `dark:text-*` and `dark:prose-invert` Tailwind classes to components that were missing them.

## Changes
- **RichTextEditor** (`apps/webapp/src/components/ui/rich-text-editor.tsx`): Added `dark:prose-invert` to the prose class. This fix affects 5 editor instances across the app (documents page, goal log forms, goal edit modal, goal edit popover, scratchpad).
- **Installation docs** (`apps/webapp/src/app/docs/installation/page.tsx`): Added `dark:text-slate-400` to 3 instructional paragraphs.
- **GoalDetailsPopoverView** (`apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx`): Added `dark:text-gray-400` to title class name.
- **PastDaysContainer** (`apps/webapp/src/components/molecules/day-of-week/containers/PastDaysContainer.tsx`): Added `dark:text-gray-400` and `dark:text-gray-500` to task completion indicator.
- **QuarterActionMenu** (`apps/webapp/src/components/molecules/quarter/QuarterActionMenu.tsx`): Added `dark:text-gray-400` to "from previous quarter" label.
- **WeekCardPreviewDialog** (`apps/webapp/src/components/organisms/WeekCardPreviewDialog.tsx`): Added `dark:text-gray-400` to empty state message.

## Verification
- `pnpm typecheck` — passes
- `pnpm test` — all 61 backend + 104 frontend tests pass

## Notes
The RichTextEditor fix has the highest impact since it is a shared component used in 5 places. The other changes are low-risk single-line additions.