### PR TITLE
fix(webapp): restore view-mode hotkeys in standalone PWA

### DIFF
--- a/apps/webapp/src/components/molecules/focus/ViewModeKeyboardShortcuts.test.tsx
+++ b/apps/webapp/src/components/molecules/focus/ViewModeKeyboardShortcuts.test.tsx
@@ -18,7 +18,7 @@ describe('ViewModeKeyboardShortcuts', () => {
   });
 
   function pressKey(key: string, init: KeyboardEventInit = {}) {
-    window.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...init }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, ...init }));
   }
 
   it('switches view when body is focused', () => {

--- a/apps/webapp/src/components/molecules/focus/ViewModeKeyboardShortcuts.tsx
+++ b/apps/webapp/src/components/molecules/focus/ViewModeKeyboardShortcuts.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import type { ViewMode } from '@/components/molecules/focus/constants';
 import { isTypingTarget } from '@/lib/keyboard/isTypingTarget';
+import { setupPwaKeyboardFocusIfNeeded } from '@/lib/keyboard/setupPwaKeyboardFocus';
 
 const VIEW_MODE_BY_KEY: Partial<Record<string, ViewMode>> = {
   d: 'daily',
@@ -80,8 +81,14 @@ export function ViewModeKeyboardShortcuts({
       handleViewModeKeyDown(e, onViewModeChange, onOpenQuarterJump);
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    // Capture on document is more reliable than bubble on window in standalone PWAs.
+    document.addEventListener('keydown', handleKeyDown, true);
+    const cleanupPwaFocus = setupPwaKeyboardFocusIfNeeded();
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      cleanupPwaFocus?.();
+    };
   }, [onViewModeChange, enabled, onOpenQuarterJump]);
 
   return null;

--- a/apps/webapp/src/lib/keyboard/setupPwaKeyboardFocus.test.ts
+++ b/apps/webapp/src/lib/keyboard/setupPwaKeyboardFocus.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPwaKeyboardFocusIfNeeded } from './setupPwaKeyboardFocus';
+
+describe('setupPwaKeyboardFocusIfNeeded', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', { ...navigator, standalone: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.removeAttribute('tabindex');
+  });
+
+  function setup() {
+    const cleanup = setupPwaKeyboardFocusIfNeeded();
+    if (!cleanup) {
+      throw new Error('Expected PWA keyboard focus setup in standalone mode');
+    }
+    return cleanup;
+  }
+
+  it('returns undefined outside standalone PWA mode', () => {
+    vi.stubGlobal('navigator', { ...navigator, standalone: false });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: () => ({ matches: false }),
+    });
+
+    expect(setupPwaKeyboardFocusIfNeeded()).toBeUndefined();
+  });
+
+  it('makes body focusable and focuses it on setup', () => {
+    const cleanup = setup();
+
+    expect(document.body.tabIndex).toBe(-1);
+    expect(document.activeElement).toBe(document.body);
+
+    cleanup();
+  });
+
+  it('refocuses body after pointerup on non-typing targets', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.focus();
+
+    const cleanup = setup();
+    button.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+
+    expect(document.activeElement).toBe(document.body);
+
+    document.body.removeChild(button);
+    cleanup();
+  });
+
+  it('does not refocus body after pointerup on text inputs', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.appendChild(input);
+
+    const cleanup = setup();
+    input.focus();
+    input.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+
+    expect(document.activeElement).toBe(input);
+
+    document.body.removeChild(input);
+    cleanup();
+  });
+
+  it('restores previous tabindex on cleanup', () => {
+    document.body.setAttribute('tabindex', '0');
+
+    const cleanup = setup();
+    cleanup();
+
+    expect(document.body.getAttribute('tabindex')).toBe('0');
+  });
+});

--- a/apps/webapp/src/lib/keyboard/setupPwaKeyboardFocus.ts
+++ b/apps/webapp/src/lib/keyboard/setupPwaKeyboardFocus.ts
@@ -1,0 +1,58 @@
+import { isTypingTarget } from '@/lib/keyboard/isTypingTarget';
+
+function isStandalonePwa(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  if (navigatorWithStandalone.standalone) {
+    return true;
+  }
+
+  const matchMedia = window.matchMedia;
+  if (typeof matchMedia !== 'function') {
+    return false;
+  }
+
+  return ['standalone', 'fullscreen'].some((mode) => matchMedia(`(display-mode: ${mode})`).matches);
+}
+
+/**
+ * Ensures the document can receive keyboard events in standalone PWA mode.
+ *
+ * WebKit standalone PWAs (Add to Home Screen) often do not deliver keydown events
+ * until the page has keyboard focus — unlike the same site in a Safari tab.
+ * Making body focusable and refocusing after non-typing interactions keeps
+ * single-key shortcuts working after normal UI use.
+ */
+function setupPwaKeyboardFocus(): () => void {
+  const body = document.body;
+  const previousTabIndex = body.getAttribute('tabindex');
+
+  body.tabIndex = -1;
+  body.focus({ preventScroll: true });
+
+  const refocusBody = (event: PointerEvent) => {
+    const target = event.target;
+    if (target instanceof HTMLElement && !isTypingTarget(target)) {
+      body.focus({ preventScroll: true });
+    }
+  };
+
+  document.addEventListener('pointerup', refocusBody);
+
+  return () => {
+    document.removeEventListener('pointerup', refocusBody);
+    if (previousTabIndex === null) {
+      body.removeAttribute('tabindex');
+    } else {
+      body.setAttribute('tabindex', previousTabIndex);
+    }
+  };
+}
+
+/** Sets up PWA keyboard focus when running as an installed app; no-op otherwise. */
+export function setupPwaKeyboardFocusIfNeeded(): (() => void) | undefined {
+  return isStandalonePwa() ? setupPwaKeyboardFocus() : undefined;
+}


### PR DESCRIPTION
## Summary
- Fixes Q/W/D/F view-switching shortcuts not working when Goals is installed as a PWA (Add to Home Screen / Dock), while they work in Safari browser tabs
- Uses document capture-phase keydown listeners (more reliable in standalone WebKit)
- Adds PWA-specific focus management: makes body focusable and refocuses after non-typing UI interactions, without stealing focus from text inputs

## Context
PR #58 fixed hotkeys in Safari browser by replacing a strict `document.body` focus check with `isTypingTarget()`. This PR addresses a separate WebKit standalone-mode issue where keydown events are not delivered until the page has keyboard focus.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [ ] Install PWA on iOS/macOS and verify Q/W/D/F switch views
- [ ] Click a menu button, then press F — should still switch
- [ ] Focus a text field — shortcuts suppressed; Cmd+K still opens search

Made with [Cursor](https://cursor.com)