### PR TITLE
fix(webapp): normalize dashboard URL params on view mode change

### DIFF
--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { DashboardFocusView } from '@/components/organisms/DashboardFocusView';
 import { useDashboard } from '@/hooks/useDashboard';
 import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
+import { buildMissingDashboardDefaults } from '@/lib/dashboard/dashboardUrlParams';
 
 /**
  * Main dashboard page displaying goals in quarterly, weekly, or daily views.
@@ -18,6 +19,8 @@ const DashboardPage = () => {
     selectedWeek,
     selectedDayOfWeek,
     viewMode,
+    currentYear,
+    currentQuarter,
     handleViewModeChange,
     handleYearQuarterChange,
     handlePrevious,
@@ -25,33 +28,33 @@ const DashboardPage = () => {
     updateUrlParams,
   } = useDashboard();
 
-  // Set default parameters when first loading the page
+  // Persist canonical defaults when first loading the page without navigation params.
   useEffect(() => {
-    const params: Record<string, string> = {};
-    let shouldUpdateUrl = false;
+    const missingDefaults = buildMissingDashboardDefaults(
+      searchParams,
+      viewMode,
+      {
+        year: currentYear,
+        quarter: currentQuarter,
+        week: currentWeekNumber,
+        day: selectedDayOfWeek,
+      },
+      isMobile
+    );
 
-    // Set default view mode if not present
-    if (!searchParams.get('view-mode')) {
-      params.viewMode = isMobile ? 'focused' : 'quarterly';
-      shouldUpdateUrl = true;
+    if (missingDefaults) {
+      updateUrlParams(missingDefaults);
     }
-
-    // Set default week if in weekly/daily mode and week not set
-    if ((viewMode === 'weekly' || viewMode === 'daily') && !searchParams.get('week')) {
-      params.week = currentWeekNumber.toString();
-      shouldUpdateUrl = true;
-    }
-
-    // Set default day if in daily mode and day not set
-    if (viewMode === 'daily' && !searchParams.get('day')) {
-      params.day = selectedDayOfWeek.toString();
-      shouldUpdateUrl = true;
-    }
-
-    if (shouldUpdateUrl) {
-      updateUrlParams(params);
-    }
-  }, [isMobile, searchParams, viewMode, currentWeekNumber, selectedDayOfWeek, updateUrlParams]);
+  }, [
+    isMobile,
+    searchParams,
+    viewMode,
+    currentWeekNumber,
+    selectedDayOfWeek,
+    currentYear,
+    currentQuarter,
+    updateUrlParams,
+  ]);
 
   return (
     <div className="flex flex-col h-full overflow-hidden">

--- a/apps/webapp/src/hooks/useDashboard.tsx
+++ b/apps/webapp/src/hooks/useDashboard.tsx
@@ -10,6 +10,12 @@ import { useQuarterWeekInfo } from './useQuarterWeekInfo';
 import type { ViewMode } from '@/components/molecules/focus/constants';
 import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import { DayOfWeek } from '@/lib/constants';
+import {
+  applyDashboardUrlUpdates,
+  buildUrlParamsForViewModeChange,
+  parseViewMode,
+  type DashboardUrlUpdates,
+} from '@/lib/dashboard/dashboardUrlParams';
 import { getWeeksInYear } from '@/lib/date/iso-week';
 
 export const useDashboard = () => {
@@ -53,14 +59,7 @@ interface DashboardContextValue {
   isFocusModeEnabled: boolean;
 
   // URL update functions
-  updateUrlParams: (params: {
-    week?: number;
-    day?: DayOfWeek;
-    viewMode?: ViewMode;
-    year?: number;
-    quarter?: number;
-    focusMode?: boolean;
-  }) => void;
+  updateUrlParams: (params: DashboardUrlUpdates) => void;
   handleViewModeChange: (newViewMode: ViewMode) => void;
   handleYearQuarterChange: (year: number, quarter: number) => void;
   handlePrevious: () => void;
@@ -103,8 +102,8 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
   );
 
   // Get view mode from URL or use default based on screen size
-  const viewModeFromUrl = searchParams.get('view-mode') as ViewMode | null;
-  const viewMode = viewModeFromUrl || (isMobile ? 'focused' : 'quarterly');
+  const defaultViewMode: ViewMode = isMobile ? 'focused' : 'quarterly';
+  const viewMode = parseViewMode(searchParams.get('view-mode'), defaultViewMode);
 
   // Get selected week from URL or use current week
   const weekFromUrl = searchParams.get('week');
@@ -131,43 +130,21 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
         ? false // No bounds in daily view - can navigate freely
         : false; // No bounds in weekly view - can navigate freely
 
+  const navigationDefaults = useMemo(
+    () => ({
+      year: currentYear,
+      quarter: currentQuarter,
+      week: currentWeekNumber,
+      day: currentDate.weekday as DayOfWeek,
+    }),
+    [currentYear, currentQuarter, currentWeekNumber, currentDate.weekday]
+  );
+
   // Update URL helper function
   const updateUrlParams = useCallback(
-    (params: {
-      week?: number;
-      day?: DayOfWeek;
-      viewMode?: ViewMode;
-      year?: number;
-      quarter?: number;
-      focusMode?: boolean;
-    }) => {
-      const newParams = new URLSearchParams(searchParams.toString());
-
-      if (params.week !== undefined) {
-        newParams.set('week', params.week.toString());
-      }
-
-      if (params.day !== undefined) {
-        newParams.set('day', params.day.toString());
-      }
-
-      if (params.viewMode !== undefined) {
-        newParams.set('view-mode', params.viewMode);
-      }
-
-      if (params.year !== undefined) {
-        newParams.set('year', params.year.toString());
-      }
-
-      if (params.quarter !== undefined) {
-        newParams.set('quarter', params.quarter.toString());
-      }
-
-      if (params.focusMode !== undefined) {
-        newParams.set('focus-mode', params.focusMode.toString());
-      }
-
-      router.push(`/app?${newParams.toString()}`);
+    (params: DashboardUrlUpdates) => {
+      const newParams = applyDashboardUrlUpdates(searchParams, params);
+      router.replace(`/app?${newParams.toString()}`, { scroll: false });
     },
     [router, searchParams]
   );
@@ -175,49 +152,18 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
   // Handle view mode changes
   const handleViewModeChange = useCallback(
     (newViewMode: ViewMode) => {
-      // Update URL with new view mode
-      const params: {
-        viewMode: ViewMode;
-        week?: number;
-        day?: DayOfWeek;
-        year?: number;
-        quarter?: number;
-      } = {
-        viewMode: newViewMode,
-      };
-
-      // Ensure year is always set when switching views
-      if (!searchParams.has('year')) {
-        params.year = currentYear;
+      if (newViewMode === viewMode) {
+        return;
       }
 
-      // If changing to weekly or daily view, ensure week parameter is set
-      if (newViewMode === 'weekly' || newViewMode === 'daily') {
-        if (!searchParams.has('week')) {
-          params.week = currentWeekNumber;
-        }
-      }
-
-      // If changing to daily view, ensure day parameter is set
-      if (newViewMode === 'daily' && !searchParams.has('day')) {
-        params.day = currentDate.weekday as DayOfWeek;
-      }
-
-      // If changing to quarterly view, ensure quarter parameter is set
-      if (newViewMode === 'quarterly' && !searchParams.has('quarter')) {
-        params.quarter = currentQuarter;
-      }
-
-      updateUrlParams(params);
+      const newParams = buildUrlParamsForViewModeChange(
+        searchParams,
+        newViewMode,
+        navigationDefaults
+      );
+      router.replace(`/app?${newParams.toString()}`, { scroll: false });
     },
-    [
-      updateUrlParams,
-      searchParams,
-      currentWeekNumber,
-      currentDate.weekday,
-      currentYear,
-      currentQuarter,
-    ]
+    [navigationDefaults, router, searchParams, viewMode]
   );
 
   // Handle year and quarter changes

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyDashboardUrlUpdates,
+  buildMissingDashboardDefaults,
+  buildUrlParamsForViewModeChange,
+  parseViewMode,
+} from './dashboardUrlParams';
+
+import { DayOfWeek } from '@/lib/constants';
+
+const defaults = {
+  year: 2026,
+  quarter: 2 as const,
+  week: 24,
+  day: DayOfWeek.WEDNESDAY,
+};
+
+describe('parseViewMode', () => {
+  it('returns valid view modes from the URL', () => {
+    expect(parseViewMode('focused', 'quarterly')).toBe('focused');
+  });
+
+  it('falls back for invalid values', () => {
+    expect(parseViewMode('invalid', 'quarterly')).toBe('quarterly');
+    expect(parseViewMode(null, 'daily')).toBe('daily');
+  });
+});
+
+describe('buildUrlParamsForViewModeChange', () => {
+  it('drops stale week/day/quarter params when switching to focused', () => {
+    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
+
+    const next = buildUrlParamsForViewModeChange(current, 'focused', defaults);
+
+    expect(next.get('view-mode')).toBe('focused');
+    expect(next.get('year')).toBe('2026');
+    expect(next.has('week')).toBe(false);
+    expect(next.has('day')).toBe(false);
+    expect(next.has('quarter')).toBe(false);
+  });
+
+  it('keeps only quarterly params when switching to quarterly', () => {
+    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
+
+    const next = buildUrlParamsForViewModeChange(current, 'quarterly', defaults);
+
+    expect(next.get('view-mode')).toBe('quarterly');
+    expect(next.get('year')).toBe('2026');
+    expect(next.get('quarter')).toBe('1');
+    expect(next.has('week')).toBe(false);
+    expect(next.has('day')).toBe(false);
+  });
+
+  it('keeps week but drops day and quarter when switching to weekly', () => {
+    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
+
+    const next = buildUrlParamsForViewModeChange(current, 'weekly', defaults);
+
+    expect(next.get('view-mode')).toBe('weekly');
+    expect(next.get('year')).toBe('2026');
+    expect(next.get('week')).toBe('10');
+    expect(next.has('day')).toBe(false);
+    expect(next.has('quarter')).toBe(false);
+  });
+
+  it('keeps week and day when switching to daily', () => {
+    const current = new URLSearchParams('view-mode=focused&year=2026&quarter=3');
+
+    const next = buildUrlParamsForViewModeChange(current, 'daily', defaults);
+
+    expect(next.get('view-mode')).toBe('daily');
+    expect(next.get('year')).toBe('2026');
+    expect(next.get('week')).toBe('24');
+    expect(next.get('day')).toBe(String(DayOfWeek.WEDNESDAY));
+    expect(next.has('quarter')).toBe(false);
+  });
+});
+
+describe('applyDashboardUrlUpdates', () => {
+  it('merges partial updates onto existing params', () => {
+    const current = new URLSearchParams('view-mode=weekly&week=10&year=2026');
+    const next = applyDashboardUrlUpdates(current, { week: 11 });
+
+    expect(next.get('week')).toBe('11');
+    expect(next.get('view-mode')).toBe('weekly');
+  });
+});
+
+describe('buildMissingDashboardDefaults', () => {
+  it('returns null when all required params already exist', () => {
+    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
+
+    expect(buildMissingDashboardDefaults(current, 'daily', defaults, false)).toBeNull();
+  });
+
+  it('fills missing defaults for a new dashboard visit', () => {
+    const current = new URLSearchParams();
+
+    expect(buildMissingDashboardDefaults(current, 'quarterly', defaults, false)).toEqual({
+      viewMode: 'quarterly',
+      year: 2026,
+      quarter: 2,
+    });
+  });
+});

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
@@ -1,0 +1,191 @@
+import type { ViewMode } from '@/components/molecules/focus/constants';
+import { DayOfWeek } from '@/lib/constants';
+import { getQuarterFromWeek } from '@/lib/date/iso-week';
+
+const VIEW_MODES: readonly ViewMode[] = ['daily', 'weekly', 'quarterly', 'focused'];
+
+export interface DashboardNavigationDefaults {
+  year: number;
+  quarter: 1 | 2 | 3 | 4;
+  week: number;
+  day: DayOfWeek;
+}
+
+export interface DashboardUrlUpdates {
+  week?: number;
+  day?: DayOfWeek;
+  viewMode?: ViewMode;
+  year?: number;
+  quarter?: number;
+  focusMode?: boolean;
+}
+
+function parsePositiveInt(value: string | null): number | undefined {
+  if (value === null) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function parseQuarter(value: string | null): 1 | 2 | 3 | 4 | undefined {
+  const parsed = parsePositiveInt(value);
+  if (parsed === undefined || parsed < 1 || parsed > 4) {
+    return undefined;
+  }
+
+  return parsed as 1 | 2 | 3 | 4;
+}
+
+function parseDay(value: string | null): DayOfWeek | undefined {
+  const parsed = parsePositiveInt(value);
+  if (parsed === undefined || parsed < DayOfWeek.MONDAY || parsed > DayOfWeek.SUNDAY) {
+    return undefined;
+  }
+
+  return parsed as DayOfWeek;
+}
+
+/** Parses a view-mode query value, falling back when missing or invalid. */
+export function parseViewMode(value: string | null, fallback: ViewMode): ViewMode {
+  if (value !== null && VIEW_MODES.includes(value as ViewMode)) {
+    return value as ViewMode;
+  }
+
+  return fallback;
+}
+
+/**
+ * Builds canonical dashboard URL search params for a view-mode change.
+ *
+ * When every navigation param is present in the URL, stale week/day/quarter values
+ * can disagree and make view switches appear to do nothing. Each view mode keeps
+ * only the params it needs and drops the rest.
+ */
+// fallow-ignore-next-line complexity
+export function buildUrlParamsForViewModeChange(
+  current: URLSearchParams,
+  newViewMode: ViewMode,
+  defaults: DashboardNavigationDefaults
+): URLSearchParams {
+  const next = new URLSearchParams(current.toString());
+  next.set('view-mode', newViewMode);
+
+  const year = parsePositiveInt(current.get('year')) ?? defaults.year;
+  const week = parsePositiveInt(current.get('week')) ?? defaults.week;
+  const day = parseDay(current.get('day')) ?? defaults.day;
+  const quarter =
+    parseQuarter(current.get('quarter')) ?? getQuarterFromWeek(week) ?? defaults.quarter;
+
+  next.set('year', year.toString());
+
+  switch (newViewMode) {
+    case 'quarterly': {
+      next.set('quarter', quarter.toString());
+      next.delete('week');
+      next.delete('day');
+      break;
+    }
+    case 'weekly': {
+      next.set('week', week.toString());
+      next.delete('quarter');
+      next.delete('day');
+      break;
+    }
+    case 'daily': {
+      next.set('week', week.toString());
+      next.set('day', day.toString());
+      next.delete('quarter');
+      break;
+    }
+    case 'focused': {
+      next.delete('week');
+      next.delete('day');
+      next.delete('quarter');
+      break;
+    }
+  }
+
+  return next;
+}
+
+/** Applies partial dashboard navigation updates onto existing search params. */
+// fallow-ignore-next-line complexity
+export function applyDashboardUrlUpdates(
+  current: URLSearchParams,
+  updates: DashboardUrlUpdates
+): URLSearchParams {
+  const next = new URLSearchParams(current.toString());
+
+  if (updates.week !== undefined) {
+    next.set('week', updates.week.toString());
+  }
+
+  if (updates.day !== undefined) {
+    next.set('day', updates.day.toString());
+  }
+
+  if (updates.viewMode !== undefined) {
+    next.set('view-mode', updates.viewMode);
+  }
+
+  if (updates.year !== undefined) {
+    next.set('year', updates.year.toString());
+  }
+
+  if (updates.quarter !== undefined) {
+    next.set('quarter', updates.quarter.toString());
+  }
+
+  if (updates.focusMode !== undefined) {
+    next.set('focus-mode', updates.focusMode.toString());
+  }
+
+  return next;
+}
+
+/** Returns default URL updates for a dashboard that has not persisted params yet. */
+// fallow-ignore-next-line complexity
+export function buildMissingDashboardDefaults(
+  current: URLSearchParams,
+  viewMode: ViewMode,
+  defaults: DashboardNavigationDefaults,
+  isMobile: boolean
+): DashboardUrlUpdates | null {
+  const updates: DashboardUrlUpdates = {};
+  let hasUpdates = false;
+
+  if (!current.has('view-mode')) {
+    updates.viewMode = isMobile ? 'focused' : 'quarterly';
+    hasUpdates = true;
+  }
+
+  const effectiveViewMode = updates.viewMode ?? parseViewMode(current.get('view-mode'), viewMode);
+
+  if (!current.has('year')) {
+    updates.year = defaults.year;
+    hasUpdates = true;
+  }
+
+  if (effectiveViewMode === 'quarterly' && !current.has('quarter')) {
+    updates.quarter = defaults.quarter;
+    hasUpdates = true;
+  }
+
+  if ((effectiveViewMode === 'weekly' || effectiveViewMode === 'daily') && !current.has('week')) {
+    updates.week = defaults.week;
+    hasUpdates = true;
+  }
+
+  if (effectiveViewMode === 'daily' && !current.has('day')) {
+    updates.day = defaults.day;
+    hasUpdates = true;
+  }
+
+  return hasUpdates ? updates : null;
+}


### PR DESCRIPTION
## Summary
- Fixes view-mode dropdown/keyboard switches appearing to do nothing when the URL contains all navigation params (`view-mode`, `week`, `day`, `year`, `quarter`) with stale or conflicting values
- Adds `dashboardUrlParams` helpers to validate `view-mode`, canonicalize URL state per view mode, and drop irrelevant params on view switches
- Uses `router.replace` (with `scroll: false`) for in-dashboard navigation to avoid history/focus quirks in PWA

## Root cause
Dashboard state is fully URL-driven. When every navigation param was present, switching view modes only updated `view-mode` while leaving stale `week`/`day`/`quarter` values that could disagree. That made view switches appear broken—especially noticeable in the installed PWA.

## Changes
- `apps/webapp/src/lib/dashboard/dashboardUrlParams.ts` — parse, normalize, and apply dashboard URL params
- `apps/webapp/src/hooks/useDashboard.tsx` — use canonical view-mode URL builder; validate view-mode from URL
- `apps/webapp/src/app/app/page.tsx` — use shared default-param helper

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] In PWA with URL like `?view-mode=daily&week=10&day=5&year=2026&quarter=1`, switch views via ⋮ menu — URL should canonicalize (e.g. focused drops week/day/quarter) and UI should update
- [ ] Confirm Q/W/D/F shortcuts still work after view switches
- [ ] Confirm first visit without params still gets sensible defaults written to URL

Made with [Cursor](https://cursor.com)