### PR TITLE
Improve focused UX surfaces

### DIFF
--- a/apps/webapp/src/components/molecules/day-of-week/containers/PastDaysContainer.tsx
+++ b/apps/webapp/src/components/molecules/day-of-week/containers/PastDaysContainer.tsx
@@ -42,8 +42,8 @@ export const PastDaysContainer = ({
       <CollapsibleMinimalTrigger>
         <div className="flex justify-between w-full items-center">
           <span className="font-medium">Past Days</span>
-          <div className="flex items-center text-gray-600 dark:text-gray-400 text-sm whitespace-nowrap ml-2">
-            <Check className="w-3.5 h-3.5 mr-1 text-gray-400 dark:text-gray-500" />
+          <div className="flex items-center text-muted-foreground text-sm whitespace-nowrap ml-2">
+            <Check className="w-3.5 h-3.5 mr-1 text-muted-foreground/80" />
             <span>
               {completedTasks}/{totalTasks}
             </span>

--- a/apps/webapp/src/components/molecules/focus/FocusMenuBar.tsx
+++ b/apps/webapp/src/components/molecules/focus/FocusMenuBar.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import { DateTime } from 'luxon';
 import type { ReactElement } from 'react';
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 
 import type { ViewMode } from '@/components/molecules/focus/constants';
 import { DailyWeeklyActionMenu } from '@/components/molecules/focus/DailyWeeklyActionMenu';
@@ -173,16 +173,17 @@ export const FocusMenuBar = ({
   return (
     <>
       <div className="bg-background p-3 border-b">
-        <div className="max-w-screen-2xl mx-auto px-2 sm:px-4 flex justify-center">
-          <div id="focus-menu-bar" className="flex items-center justify-center w-full">
-            <div className="flex items-center gap-1 sm:gap-2">
-              {/* ── Focused view: date label + view-switch dropdown ─────────── */}
-              {viewMode === 'focused' ? (
-                <>
-                  <span className="text-xs font-bold uppercase tracking-wider text-foreground">
+        <div className="max-w-screen-2xl mx-auto px-2 sm:px-4 flex justify-between">
+          <div id="focus-menu-bar" className="flex items-center justify-between w-full gap-2">
+            {viewMode === 'focused' ? (
+              <Fragment>
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-bold uppercase tracking-wider text-foreground">
                     Focus — {DateTime.now().toFormat('cccc, MMMM d')}
                   </span>
+                </div>
 
+                <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
                   {/* Search button — opens command palette */}
                   {onOpenCommandPalette && (
                     <TooltipProvider>
@@ -193,7 +194,7 @@ export const FocusMenuBar = ({
                             size="icon"
                             onClick={onOpenCommandPalette}
                             className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                            aria-label="Search"
+                            aria-label="Open search"
                           >
                             <Search className="h-4 w-4" />
                           </Button>
@@ -208,7 +209,12 @@ export const FocusMenuBar = ({
                   {/* View-switch + actions dropdown */}
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        aria-label="Open focused view menu"
+                      >
                         <MoreVertical className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>
@@ -278,9 +284,11 @@ export const FocusMenuBar = ({
 
                   {/* Pull goals dialog must be in the DOM */}
                   {pullGoalsDialog}
-                </>
-              ) : (
-                <>
+                </div>
+              </Fragment>
+            ) : (
+              <Fragment>
+                <div className="min-w-0 flex-1 justify-start">
                   {/* Navigation with unified indicator */}
                   {showNavigation && (
                     <div className="flex items-center gap-0.5 sm:gap-1">
@@ -310,7 +318,9 @@ export const FocusMenuBar = ({
                       </Button>
                     </div>
                   )}
+                </div>
 
+                <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
                   {/* Quarter Action Menu - with vertical dots icon and view mode options */}
                   {showQuarterActionMenu && (
                     <QuarterActionMenu
@@ -356,7 +366,7 @@ export const FocusMenuBar = ({
                             size="icon"
                             onClick={onOpenCommandPalette}
                             className="h-9 w-9 text-muted-foreground hover:text-foreground"
-                            aria-label="Search"
+                            aria-label="Open search"
                           >
                             <Search className="h-4 w-4" />
                           </Button>
@@ -367,9 +377,9 @@ export const FocusMenuBar = ({
                       </Tooltip>
                     </TooltipProvider>
                   )}
-                </>
-              )}
-            </div>
+                </div>
+              </Fragment>
+            )}
           </div>
         </div>
       </div>

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
@@ -196,7 +196,7 @@ export const GoalPopoverTrigger = forwardRef<HTMLButtonElement, GoalPopoverTrigg
       title,
       variant = 'ghost',
       className = 'p-0 h-auto hover:bg-transparent font-normal justify-start text-left flex-1 focus-visible:ring-0 min-w-0 w-full mb-1 normal-case tracking-normal',
-      titleClassName = 'text-gray-600 dark:text-gray-400',
+      titleClassName = 'text-muted-foreground',
       ...props
     },
     ref

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsChildrenList.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsChildrenList.tsx
@@ -74,7 +74,7 @@ export function GoalDetailsChildrenList({
 
   return (
     <div className="mt-3">
-      <h4 className="text-sm font-semibold mb-3 text-foreground bg-gray-50 dark:bg-gray-800 py-1.5 px-4 rounded-md">
+      <h4 className="text-sm font-semibold mb-3 text-foreground bg-muted/60 py-1.5 px-4 rounded-md">
         {title}
       </h4>
       <GoalActionsProvider onUpdateGoal={handleUpdateGoal} onDeleteGoal={_handleDeleteGoal}>
@@ -93,7 +93,7 @@ export function GoalDetailsChildrenList({
                 {/* If the parent is a quarterly goal and we have grandchildren (daily goals), 
                     show them indented under their weekly parent */}
                 {isQuarterlyParent && child.children && child.children.length > 0 && (
-                  <div className="ml-6 mt-1 mb-2 space-y-1 border-l-2 border-gray-100 dark:border-gray-800 pl-3">
+                  <div className="ml-6 mt-1 mb-2 space-y-1 border-l-2 border-border pl-3">
                     {child.children.map((grandchild) => (
                       <GoalProvider key={grandchild._id} goal={grandchild}>
                         <DailyGoalTaskItem />

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -20,6 +20,8 @@ export interface GoalDetailsContentProps {
   className?: string;
   /** Whether to show the title above the content */
   showTitle?: boolean;
+  /** Whether to show the full-view expand action above the content */
+  showExpandAction?: boolean;
   /** Callback when task list items are checked/unchecked */
   onDetailsChange?: (newDetails: string) => void;
   /** If true, task list checkboxes are disabled */
@@ -46,6 +48,7 @@ export function GoalDetailsContent({
   details,
   className,
   showTitle = false,
+  showExpandAction = true,
   onDetailsChange,
   readOnly = false,
 }: GoalDetailsContentProps) {
@@ -55,20 +58,26 @@ export function GoalDetailsContent({
   return (
     <>
       <div className="space-y-3">
-        {showTitle && (
+        {(showTitle || showExpandAction) && (
           <div className="flex items-center justify-between gap-3 border-b-2 border-border px-4 py-3">
-            <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 text-xs uppercase tracking-wider font-bold"
-              onClick={() => setIsFullViewOpen(true)}
-              title="Expand to full view"
-              aria-label="Expand goal details"
-            >
-              <Maximize2 className="h-3.5 w-3.5 mr-1" />
-              Expand
-            </Button>
+            {showTitle ? (
+              <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
+            ) : (
+              <div className="flex-1" />
+            )}
+            {showExpandAction && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 text-xs uppercase tracking-wider font-bold"
+                onClick={() => setIsFullViewOpen(true)}
+                title="Expand to full view"
+                aria-label="Expand goal details"
+              >
+                <Maximize2 className="h-3.5 w-3.5 mr-1" />
+                Expand
+              </Button>
+            )}
           </div>
         )}
 

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -28,7 +28,7 @@ export interface GoalDetailsContentProps {
 
 /**
  * Displays goal details content with an expandable full view dialog.
- * Shows HTML content in a scrollable container with an expand button on hover.
+ * Shows HTML content in a scrollable container with an always-visible expand action.
  * Supports interactive task lists with checkable items.
  *
  * @example
@@ -56,17 +56,23 @@ export function GoalDetailsContent({
     <>
       <div className="space-y-3">
         {showTitle && (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center justify-between gap-3 border-b-2 border-border px-4 py-3">
             <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs uppercase tracking-wider font-bold"
+              onClick={() => setIsFullViewOpen(true)}
+              title="Expand to full view"
+              aria-label="Expand goal details"
+            >
+              <Maximize2 className="h-3.5 w-3.5 mr-1" />
+              Expand
+            </Button>
           </div>
         )}
 
-        <div
-          className={cn(
-            'max-h-[300px] overflow-y-auto rounded-md pt-4 pb-4 px-3 relative group bg-muted/30',
-            className
-          )}
-        >
+        <div className={cn('overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30', className)}>
           {hasInteractiveFeatures ? (
             <InteractiveHTML
               html={details}
@@ -80,11 +86,6 @@ export function GoalDetailsContent({
               className="text-sm prose prose-sm dark:prose-invert max-w-none"
             />
           )}
-
-          {/* Absolutely positioned expand button */}
-          <div className="absolute top-0 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none group-hover:pointer-events-auto">
-            <_ExpandButton onClick={() => setIsFullViewOpen(true)} />
-          </div>
         </div>
       </div>
 
@@ -112,22 +113,5 @@ export function GoalDetailsContent({
         </FixedSizeDialog>
       </Dialog>
     </>
-  );
-}
-
-/**
- * Internal expand button component for triggering full view dialog.
- */
-function _ExpandButton({ onClick }: { onClick: () => void }) {
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-5 w-5 text-muted-foreground hover:text-foreground flex-shrink-0 rounded-full bg-background/80 backdrop-blur-sm shadow-sm"
-      onClick={onClick}
-      title="Expand to full view"
-    >
-      <Maximize2 className="h-3 w-3" />
-    </Button>
   );
 }

--- a/apps/webapp/src/components/molecules/goal-list-item/variants/QuarterlyGoalItem.tsx
+++ b/apps/webapp/src/components/molecules/goal-list-item/variants/QuarterlyGoalItem.tsx
@@ -139,7 +139,7 @@ function QuarterlyGoalItemContentInternal({
           onSave={handleSaveGoal}
           triggerClassName="p-0 h-auto hover:bg-transparent font-normal justify-start text-left flex-1 focus-visible:ring-0 min-w-0 w-full"
           titleClassName={cn(
-            'text-gray-600 dark:text-gray-300 flex items-center',
+            'text-muted-foreground flex items-center',
             getDueDateStyle(goal.dueDate ? new Date(goal.dueDate) : null, goal.isComplete)
           )}
           onToggleComplete={handleToggleCompletion}

--- a/apps/webapp/src/components/molecules/multi-week/MultiWeekLayout.tsx
+++ b/apps/webapp/src/components/molecules/multi-week/MultiWeekLayout.tsx
@@ -9,6 +9,7 @@ import {
 } from '@dnd-kit/core';
 import { api } from '@workspace/backend/convex/_generated/api';
 import { useMutation } from 'convex/react';
+import { ClipboardList, CalendarDays, Rocket, Target } from 'lucide-react';
 import { DateTime } from 'luxon';
 import type React from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -92,7 +93,7 @@ const WeekCardContent = ({
       weekData={weekData}
     >
       <div className="space-y-2 md:space-y-4">
-        <WeekCardSection title="💭 Quarterly Goals">
+        <WeekCardSection title={<SectionTitle icon={<Target />} text="Quarterly Goals" />}>
           <WeekCardQuarterlyGoals
             weekNumber={week.weekNumber}
             year={week.year}
@@ -101,7 +102,7 @@ const WeekCardContent = ({
           />
         </WeekCardSection>
 
-        <WeekCardSection title="🚀 Weekly Goals">
+        <WeekCardSection title={<SectionTitle icon={<Rocket />} text="Weekly Goals" />}>
           <WeekCardWeeklyGoals
             weekNumber={week.weekNumber}
             year={week.year}
@@ -110,7 +111,7 @@ const WeekCardContent = ({
           />
         </WeekCardSection>
 
-        <WeekCardSection title="📋 Adhoc Tasks">
+        <WeekCardSection title={<SectionTitle icon={<ClipboardList />} text="Ad hoc Tasks" />}>
           <AdhocGoalsSection
             year={week.year}
             weekNumber={week.weekNumber}
@@ -119,7 +120,7 @@ const WeekCardContent = ({
           />
         </WeekCardSection>
 
-        <WeekCardSection title="🔍 Daily Goals">
+        <WeekCardSection title={<SectionTitle icon={<CalendarDays />} text="Daily Goals" />}>
           <WeekCardDailyGoals weekNumber={week.weekNumber} year={week.year} isLoading={isLoading} />
         </WeekCardSection>
       </div>
@@ -385,9 +386,16 @@ export const MultiWeekLayout = memo(() => {
 MultiWeekLayout.displayName = 'MultiWeekLayout';
 
 interface WeekCardSectionProps {
-  title: string;
+  title: React.ReactNode;
   children?: React.ReactNode;
 }
+
+const SectionTitle = ({ icon, text }: { icon: React.ReactNode; text: string }) => (
+  <div className="flex items-center gap-2">
+    <span className="text-muted-foreground">{icon}</span>
+    <span>{text}</span>
+  </div>
+);
 
 const WeekCardSection = memo(({ title, children }: WeekCardSectionProps) => {
   return (

--- a/apps/webapp/src/components/molecules/quarter/QuarterActionMenu.tsx
+++ b/apps/webapp/src/components/molecules/quarter/QuarterActionMenu.tsx
@@ -150,9 +150,7 @@ export const QuarterActionMenu = React.memo(
                       <History className="mr-2 h-4 w-4" />
                       <div className="flex flex-col w-full items-center">
                         <span>Pull Incomplete</span>
-                        <span className="text-gray-500 dark:text-gray-400 text-xs">
-                          from previous quarter
-                        </span>
+                        <span className="text-muted-foreground text-xs">from previous quarter</span>
                       </div>
                     </DropdownMenuItem>
                   </div>

--- a/apps/webapp/src/components/organisms/WeekCardPreviewDialog.tsx
+++ b/apps/webapp/src/components/organisms/WeekCardPreviewDialog.tsx
@@ -302,7 +302,7 @@ export const WeekCardPreviewDialog = ({
                 <span className="block">
                   There are no incomplete tasks from the last non-empty week to move to this week.
                 </span>
-                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                <div className="text-center py-8 text-muted-foreground">
                   <History className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <span className="block">
                     All tasks from the last non-empty week are complete!

--- a/apps/webapp/src/components/organisms/WeekCardWeeklyGoals.tsx
+++ b/apps/webapp/src/components/organisms/WeekCardWeeklyGoals.tsx
@@ -173,7 +173,9 @@ const WeeklyGoal = ({
                     trigger={
                       <button
                         type="button"
-                        className="text-muted-foreground opacity-0 group-hover/title:opacity-100 transition-opacity hover:text-foreground"
+                        className="text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+                        aria-label="Edit weekly goal"
+                        title="Edit weekly goal"
                       >
                         <Edit2 className="h-3.5 w-3.5" />
                       </button>

--- a/apps/webapp/src/components/organisms/focus/AdhocGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/AdhocGoalsSection.tsx
@@ -9,6 +9,7 @@ import { AdhocGoalItem } from '@/components/molecules/AdhocGoalItem';
 import { Spinner } from '@/components/ui/spinner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { toast } from '@/components/ui/use-toast';
 import { useAdhocGoals, useAdhocGoalsForWeek } from '@/hooks/useAdhocGoals';
 import { useDomains } from '@/hooks/useDomains';
 import type { DayOfWeek } from '@/lib/constants';
@@ -37,6 +38,15 @@ type _OptimisticAdhocGoal = Doc<'goals'> & {
   domain?: Doc<'domains'>;
   isOptimistic?: boolean;
   children?: _OptimisticAdhocGoal[];
+};
+
+const showErrorToast = (title: string, error: unknown) => {
+  console.error(title, error);
+  toast({
+    variant: 'destructive',
+    title,
+    description: 'Please try again.',
+  });
 };
 
 /**
@@ -185,7 +195,7 @@ export function AdhocGoalsSection({
       // Remove optimistic goal after successful creation
       setOptimisticGoals((prev) => prev.filter((g) => g._id !== tempId));
     } catch (error) {
-      console.error('Failed to create adhoc goal:', error);
+      showErrorToast('Could not create task', error);
       // Remove optimistic goal on error
       setOptimisticGoals((prev) => prev.filter((g) => g._id !== tempId));
     } finally {
@@ -201,7 +211,7 @@ export function AdhocGoalsSection({
     try {
       await updateAdhocGoal(goalId, { isComplete });
     } catch (error) {
-      console.error('Failed to update goal completion:', error);
+      showErrorToast('Could not update task', error);
     }
   };
 
@@ -215,7 +225,7 @@ export function AdhocGoalsSection({
     try {
       await updateAdhocGoal(goalId, { title, details, dueDate, domainId });
     } catch (error) {
-      console.error('Failed to update adhoc goal:', error);
+      showErrorToast('Could not update task', error);
     }
   };
 
@@ -223,7 +233,7 @@ export function AdhocGoalsSection({
     try {
       await deleteAdhocGoal(goalId);
     } catch (error) {
-      console.error('Failed to delete adhoc goal:', error);
+      showErrorToast('Could not delete task', error);
     }
   };
 
@@ -244,7 +254,7 @@ export function AdhocGoalsSection({
         return next;
       });
     } catch (error) {
-      console.error('Failed to update backlog status:', error);
+      showErrorToast('Could not update backlog status', error);
       // On error, revert optimistic update
       setPendingBacklogChanges((prev) => {
         const next = new Map(prev);
@@ -260,7 +270,7 @@ export function AdhocGoalsSection({
       setSelectedDomainId(newDomainId);
       return newDomainId;
     } catch (error) {
-      console.error('Failed to create domain:', error);
+      showErrorToast('Could not create domain', error);
       throw error;
     }
   };
@@ -280,7 +290,7 @@ export function AdhocGoalsSection({
           parentId // parent goal ID for nesting
         );
       } catch (error) {
-        console.error('Failed to create subtask:', error);
+        showErrorToast('Could not create subtask', error);
         throw error;
       }
     },

--- a/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
@@ -190,19 +190,19 @@ export function FocusModeFocusedView() {
               {/* Save status dot indicator */}
               {saveStatus === 'saving' && (
                 <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                  <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+                  <span className="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />
                   Saving
                 </span>
               )}
               {saveStatus === 'saved' && (
                 <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                  <span className="w-1.5 h-1.5 bg-emerald-400" />
+                  <span className="w-1.5 h-1.5 bg-success" />
                   Saved
                 </span>
               )}
               {saveStatus === 'error' && (
                 <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-destructive">
-                  <span className="w-1.5 h-1.5 bg-red-400" />
+                  <span className="w-1.5 h-1.5 bg-destructive" />
                   Error
                 </span>
               )}

--- a/apps/webapp/src/components/organisms/focus/FocusModeWeeklyView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeWeeklyView.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { CalendarDays, ClipboardList, Rocket, Target } from 'lucide-react';
+import { useMemo, type ReactNode } from 'react';
 
 import { WeekCardDailyGoals } from '../WeekCardDailyGoals';
 import { WeekCardQuarterlyGoals } from '../WeekCardQuarterlyGoals';
@@ -19,6 +20,13 @@ interface FocusModeWeeklyViewProps {
 
 /** Props for the inner component - excludes weekData since it uses context */
 type FocusModeWeeklyViewInnerProps = Omit<FocusModeWeeklyViewProps, 'weekData'>;
+
+const SectionHeader = ({ icon, title }: { icon: ReactNode; title: string }) => (
+  <div className="flex items-center gap-2 font-semibold text-foreground">
+    <span className="text-muted-foreground">{icon}</span>
+    <span>{title}</span>
+  </div>
+);
 
 // Inner component that uses the week context
 // Gets goal data from useWeek() context which includes optimistic updates
@@ -46,21 +54,23 @@ const FocusModeWeeklyViewInner = ({
 
   return (
     <div className="space-y-6">
-      <div className="bg-white dark:bg-card rounded-lg shadow-sm p-4">
+      <div className="bg-card rounded-lg border border-border shadow-sm p-4">
         <div className="flex justify-between items-center mb-4">
-          <div className="font-semibold text-foreground">💭 Quarterly Goals</div>
+          <SectionHeader icon={<Target className="h-4 w-4" />} title="Quarterly Goals" />
           <JumpToCurrentButton onJumpToToday={onJumpToToday} />
         </div>
         {quarterlyGoalsComponent}
       </div>
 
-      <div className="bg-white dark:bg-card rounded-lg shadow-sm p-4">
-        <div className="font-semibold text-foreground mb-4">🚀 Weekly Goals</div>
+      <div className="bg-card rounded-lg border border-border shadow-sm p-4">
+        <SectionHeader icon={<Rocket className="h-4 w-4" />} title="Weekly Goals" />
+        <div className="mb-4" />
         {weeklyGoalsComponent}
       </div>
 
-      <div className="bg-white dark:bg-card rounded-lg shadow-sm p-4">
-        <div className="font-semibold text-foreground mb-4">📋 Adhoc Tasks</div>
+      <div className="bg-card rounded-lg border border-border shadow-sm p-4">
+        <SectionHeader icon={<ClipboardList className="h-4 w-4" />} title="Adhoc Tasks" />
+        <div className="mb-4" />
         <AdhocGoalsSection
           year={year}
           weekNumber={weekNumber}
@@ -69,8 +79,9 @@ const FocusModeWeeklyViewInner = ({
         />
       </div>
 
-      <div className="bg-white dark:bg-card rounded-lg shadow-sm p-4">
-        <div className="font-semibold text-foreground mb-4">🔍 Daily Goals</div>
+      <div className="bg-card rounded-lg border border-border shadow-sm p-4">
+        <SectionHeader icon={<CalendarDays className="h-4 w-4" />} title="Daily Goals" />
+        <div className="mb-4" />
         {dailyGoalsComponent}
       </div>
     </div>

--- a/apps/webapp/src/components/organisms/focus/QuarterlyGoalsQuickSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/QuarterlyGoalsQuickSection.tsx
@@ -1,4 +1,5 @@
 import type { Id } from '@workspace/backend/convex/_generated/dataModel';
+import { Target } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { QuarterlyGoalItem } from '@/components/molecules/goal-list-item';
@@ -118,9 +119,14 @@ export function QuarterlyGoalsQuickSection({ showHeader = true }: QuarterlyGoals
     return null;
   }
 
-  const triggerText = isExpanded
-    ? '💭 Quarterly Goals'
-    : `💭 Quarterly Goals (${starredAndPinnedGoals.length})`;
+  const triggerText = (
+    <div className="flex items-center gap-2">
+      <Target className="h-4 w-4 text-muted-foreground" />
+      <span>
+        {isExpanded ? 'Quarterly Goals' : `Quarterly Goals (${starredAndPinnedGoals.length})`}
+      </span>
+    </div>
+  );
 
   return (
     <div className="mb-4">

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
@@ -26,7 +26,9 @@ export function FocusedAdhocGoalsSection({
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
         ) : goals.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-2">No tasks for today.</p>
+          <p className="px-4 py-3 text-sm text-muted-foreground">
+            No tasks for today. Add one below to capture a quick action.
+          </p>
         ) : (
           <ul className="space-y-1">
             {goals.map((goal) => (

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
@@ -1,41 +1,57 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
+export type FocusedGoalSectionTone = 'muted' | 'urgent';
+
+const toneStyles: Record<FocusedGoalSectionTone, { badge: string; dot: string; text: string }> = {
+  muted: {
+    badge: 'bg-muted/60',
+    dot: 'bg-muted-foreground',
+    text: 'text-muted-foreground',
+  },
+  urgent: {
+    badge: 'bg-red-50 dark:bg-red-950/20',
+    dot: 'bg-red-500 dark:bg-red-400',
+    text: 'text-red-800 dark:text-red-400',
+  },
+};
+
 interface FocusedGoalSectionProps {
   title: string;
+  description?: string;
   count?: number;
-  countColorClass?: string;
-  countDotColorClass?: string;
-  icon?: React.ReactNode;
-  children: React.ReactNode;
+  tone?: FocusedGoalSectionTone;
+  icon?: ReactNode;
+  children: ReactNode;
 }
 
 export function FocusedGoalSection({
   title,
+  description,
   count,
-  countColorClass = 'text-muted-foreground',
-  countDotColorClass = 'bg-muted-foreground',
+  tone = 'muted',
   icon,
   children,
 }: FocusedGoalSectionProps) {
-  // Map countDotColorClass to corresponding background for badge
-  const badgeBgClass =
-    countDotColorClass === 'bg-red-400'
-      ? 'bg-red-400/10'
-      : countDotColorClass === 'bg-amber-400'
-        ? 'bg-amber-400/10'
-        : 'bg-muted-foreground/10';
+  const styles = toneStyles[tone];
 
   return (
     <div>
       <div className="flex items-center gap-2 px-4 py-3 border-b-2 border-border">
         {icon && <span className="flex-shrink-0 text-muted-foreground">{icon}</span>}
-        <h3 className="text-xs font-bold uppercase tracking-wider text-foreground">{title}</h3>
-        {count !== undefined && count > 0 && (
+        <div className="min-w-0">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-foreground">{title}</h3>
+          {description && (
+            <p className="text-[10px] leading-4 text-muted-foreground">{description}</p>
+          )}
+        </div>
+        {count !== undefined && (
           <span
-            className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full ${badgeBgClass}`}
+            className={`inline-flex flex-shrink-0 items-center gap-1 px-1.5 py-0.5 rounded-full ${styles.badge}`}
           >
-            <span className={`w-1 h-1 rounded-full ${countDotColorClass}`} />
-            <span className={`text-[10px] font-bold tabular-nums ${countColorClass}`}>{count}</span>
+            <span className={`w-1 h-1 rounded-full ${styles.dot}`} />
+            <span className={`text-[10px] font-bold tabular-nums ${styles.text}`}>{count}</span>
           </span>
         )}
       </div>

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
@@ -18,19 +18,22 @@ export function FocusedQuarterlyGoalsSection({
   return (
     <FocusedGoalSection
       title="Quarterly Goals"
+      description="Star or pin goals to keep them visible here."
       count={goals.length}
       icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
     >
       {goals.length === 0 ? (
-        <p className="px-4 py-3 text-sm text-muted-foreground">No quarterly goals</p>
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          No quarterly goals for this week. Switch to Quarterly view to create or pin goals.
+        </p>
       ) : (
         <div className="px-4 py-2">
           <ul className="space-y-1">
             {goals.map((goal) => {
               const indicator = goal.isStarred ? (
-                <Star className="h-3 w-3 fill-amber-400 text-amber-500 dark:text-amber-400" />
+                <Star className="h-3 w-3 fill-yellow-500 text-yellow-800 dark:text-yellow-400" />
               ) : goal.isPinned ? (
-                <Pin className="h-3 w-3 fill-blue-500 text-blue-500 dark:text-blue-400" />
+                <Pin className="h-3 w-3 fill-blue-500 text-blue-800 dark:text-blue-400" />
               ) : null;
               return (
                 <FocusedGoalListItem

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
@@ -17,13 +17,15 @@ export function FocusedUrgentSection({ goals, onToggleComplete }: FocusedUrgentS
   return (
     <FocusedGoalSection
       title="Urgent"
+      description="Needs attention today."
       count={incompleteCount}
-      countColorClass="text-red-400"
-      countDotColorClass="bg-red-400"
+      tone="urgent"
       icon={<Flame className="h-3.5 w-3.5 text-red-500 dark:text-red-400" />}
     >
       {goals.length === 0 ? (
-        <p className="px-4 py-3 text-sm text-muted-foreground">No urgent goals</p>
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          No urgent goals. Mark goals urgent when they need immediate attention.
+        </p>
       ) : (
         <div className="px-4 py-2">
           <ul className="space-y-1">


### PR DESCRIPTION
Implements small, targeted frontend UX improvements across focused dashboard, weekly views, goal details, and menu ergonomics.

## Summary
- Improves empty states and count visibility in focused dashboard sections.
- Uses semantic theme tokens for focused/weekly surfaces.
- Makes goal-details expand affordance visible without hover.
- Improves focused menu-bar spacing on narrow screens and adds accessible labels.
- Adds user-facing destructive toasts for ad hoc task action failures.
- Replaces remaining goal-section emoji labels with Lucide icons.

## Verification
Passed:
- `pnpm typecheck && pnpm test`

## Notes
- Frontend-only changes.
- Existing tooling warnings remain around unused dependencies, circular dependencies, and large components.