### PR TITLE
fix(webapp): inset edit-goal modal above on-screen keyboard

### DIFF
--- a/apps/webapp/src/components/ui/dialog.tsx
+++ b/apps/webapp/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import { XIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { useAllowTouchSelection } from '@/hooks/useAllowTouchSelection';
+import { useKeyboardInsetHeight } from '@/hooks/useKeyboardInsetHeight';
 import { cn } from '@/lib/utils';
 
 /**
@@ -178,11 +179,12 @@ function DialogDescription({
 export const FullscreenDialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onEscapeKeyDown, ...props }, ref) => {
+>(({ className, children, onEscapeKeyDown, style, ...props }, ref) => {
   // Fix iOS text selection handles not being draggable
   // Must be called before react-remove-scroll attaches its listeners
   // https://github.com/theKashey/react-remove-scroll/pull/144
   useAllowTouchSelection();
+  const keyboardInset = useKeyboardInsetHeight();
 
   return (
     <DialogPortal data-slot="dialog-portal">
@@ -194,6 +196,10 @@ export const FullscreenDialogContent = React.forwardRef<
           'fixed inset-0 z-50 m-auto grid gap-4 border-2 bg-background p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg',
           className
         )}
+        style={{
+          ...style,
+          paddingBottom: keyboardInset ? `${keyboardInset}px` : style?.paddingBottom,
+        }}
         onEscapeKeyDown={onEscapeKeyDown}
         {...props}
       >

--- a/apps/webapp/src/components/ui/rich-text-editor.tsx
+++ b/apps/webapp/src/components/ui/rich-text-editor.tsx
@@ -478,6 +478,34 @@ export function RichTextEditor({
     };
   }, [editor]);
 
+  // Keep the caret visible above the on-screen keyboard on mobile when focusing.
+  useEffect(() => {
+    if (!editor) return;
+    const el = editor.view.dom as HTMLElement;
+
+    const scrollCaretIntoView = () => {
+      // Defer to next frame so the keyboard/viewport has begun resizing.
+      requestAnimationFrame(() => {
+        if (!editor || editor.isDestroyed) return;
+        const selection = window.getSelection();
+        const node =
+          selection && selection.rangeCount > 0
+            ? (selection.getRangeAt(0).startContainer as Node)
+            : null;
+        const target =
+          node && node.nodeType === Node.ELEMENT_NODE
+            ? (node as HTMLElement)
+            : (node?.parentElement ?? el);
+        target?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      });
+    };
+
+    el.addEventListener('focus', scrollCaretIntoView, true);
+    return () => {
+      el.removeEventListener('focus', scrollCaretIntoView, true);
+    };
+  }, [editor]);
+
   return (
     <div className="relative min-w-0 h-full flex flex-col overflow-hidden">
       <EditorContent editor={editor} className="overflow-y-auto flex-1 min-h-0 flex flex-col" />

--- a/apps/webapp/src/hooks/useKeyboardInsetHeight.ts
+++ b/apps/webapp/src/hooks/useKeyboardInsetHeight.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { computeKeyboardInset } from '@/lib/keyboard/computeKeyboardInset';
+
+/**
+ * Returns the height (in CSS px) the on-screen keyboard overlaps the bottom of the
+ * layout viewport, derived from `window.visualViewport`.
+ *
+ * Use this to inset fixed/fullscreen surfaces (e.g. dialogs) so their content stays
+ * visible above the keyboard on mobile/PWA. Returns 0 on desktop, during SSR, and
+ * whenever `visualViewport` is unavailable.
+ */
+export function useKeyboardInsetHeight(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const update = () => {
+      setInset(computeKeyboardInset(viewport, window.innerHeight));
+    };
+
+    update();
+    viewport.addEventListener('resize', update);
+    viewport.addEventListener('scroll', update);
+
+    return () => {
+      viewport.removeEventListener('resize', update);
+      viewport.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  return inset;
+}

--- a/apps/webapp/src/lib/keyboard/computeKeyboardInset.test.ts
+++ b/apps/webapp/src/lib/keyboard/computeKeyboardInset.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeKeyboardInset } from './computeKeyboardInset';
+
+describe('computeKeyboardInset', () => {
+  it('returns 0 when viewport is null/undefined', () => {
+    expect(computeKeyboardInset(null, 800)).toBe(0);
+    expect(computeKeyboardInset(undefined, 800)).toBe(0);
+  });
+
+  it('returns 0 when there is no overlap (keyboard closed)', () => {
+    expect(computeKeyboardInset({ height: 800, offsetTop: 0 }, 800)).toBe(0);
+  });
+
+  it('returns the overlap when the keyboard is open', () => {
+    // visible bottom = 500 + 0 = 500; overlap = 800 - 500 = 300
+    expect(computeKeyboardInset({ height: 500, offsetTop: 0 }, 800)).toBe(300);
+  });
+
+  it('accounts for visual viewport offsetTop', () => {
+    // visible bottom = 460 + 40 = 500; overlap = 800 - 500 = 300
+    expect(computeKeyboardInset({ height: 460, offsetTop: 40 }, 800)).toBe(300);
+  });
+
+  it('ignores sub-pixel overlaps', () => {
+    expect(computeKeyboardInset({ height: 799.6, offsetTop: 0 }, 800)).toBe(0);
+  });
+
+  it('returns 0 when layout height is not finite', () => {
+    expect(computeKeyboardInset({ height: 500, offsetTop: 0 }, Number.NaN)).toBe(0);
+  });
+});

--- a/apps/webapp/src/lib/keyboard/computeKeyboardInset.ts
+++ b/apps/webapp/src/lib/keyboard/computeKeyboardInset.ts
@@ -1,0 +1,36 @@
+/** Minimal shape of the parts of VisualViewport we depend on. */
+export interface VisualViewportSnapshot {
+  height: number;
+  offsetTop: number;
+}
+
+/**
+ * Computes the keyboard overlap (in CSS px) at the bottom of the layout viewport.
+ *
+ * On mobile, when the on-screen keyboard opens, `window.visualViewport` shrinks
+ * while the layout viewport (`window.innerHeight`) stays the same. The overlap is
+ * the layout height minus the visible area (visual height + how far the visual
+ * viewport is offset from the top).
+ *
+ * Returns 0 when there is no overlap or inputs are unavailable. A small threshold
+ * avoids treating sub-pixel rounding or browser chrome jitter as a keyboard.
+ */
+// fallow-ignore-next-line complexity
+export function computeKeyboardInset(
+  viewport: VisualViewportSnapshot | null | undefined,
+  layoutViewportHeight: number
+): number {
+  if (!viewport || !Number.isFinite(layoutViewportHeight)) {
+    return 0;
+  }
+
+  const visibleBottom = viewport.height + viewport.offsetTop;
+  const overlap = layoutViewportHeight - visibleBottom;
+
+  // Ignore tiny overlaps (rounding / browser UI), treat anything meaningful as keyboard.
+  if (!Number.isFinite(overlap) || overlap < 1) {
+    return 0;
+  }
+
+  return Math.round(overlap);
+}


### PR DESCRIPTION
## Summary

Fixes the bug where rich-text editor content in the edit-goal modal renders behind the on-screen keyboard on mobile/PWA.

**Root cause:** The edit-goal modal (`GoalEditPopover` → `FullscreenDialogContent`) is sized to the layout viewport (`fixed inset-0`, `h-[calc(100dvh-32px)]`). On iOS Safari / standalone PWA the layout viewport does not shrink when the keyboard opens — only `window.visualViewport` shrinks — so the dialog keeps full height and its lower region (the editor caret) ends up behind the keyboard. The existing `pb-[env(safe-area-inset-bottom)]` does not account for the keyboard.

**Fix:**
- Add a pure `computeKeyboardInset` helper and `useKeyboardInsetHeight` hook that derive keyboard overlap from `visualViewport`
- Apply the inset as `paddingBottom` on `FullscreenDialogContent` (merged with caller `style`) so the dialog scroll area stays above the keyboard
- Scroll the rich-text caret into view on focus in `RichTextEditor`

Desktop is unaffected: inset is 0 when no keyboard is present.

## Test plan

- [ ] On a mobile device / iOS PWA, open a goal's edit modal (the rich-text "Details" editor)
- [ ] Tap into the Details editor near the bottom and type — the caret and text must stay visible above the keyboard (not hidden behind it)
- [ ] Confirm the dialog content scrolls and the Save/Cancel buttons remain reachable
- [ ] Confirm desktop is unaffected
- [x] `pnpm typecheck && pnpm test` (both green; new `computeKeyboardInset` tests pass)


Made with [Cursor](https://cursor.com)