### PR TITLE
fix(webapp): constrain and pad expanded goal details modal

### DIFF
--- a/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/GoalDetailsPopoverView.tsx
@@ -122,8 +122,9 @@ export function GoalDetailsPopoverView({
               </DialogHeader>
               {/* Scrollable content area */}
               {/* pb-4 ensures content can scroll past keyboard on iOS */}
-              <div className="space-y-3 overflow-y-auto flex-1 py-1 pb-4 overscroll-contain">
-                {children}
+              <div className="overflow-y-auto flex-1 py-1 pb-4 overscroll-contain">
+                {/* Center content in a readable max-width column with horizontal padding */}
+                <div className="mx-auto w-full max-w-2xl space-y-3 px-1 sm:px-2">{children}</div>
               </div>
             </FullscreenDialogContent>
           ) : (
@@ -140,8 +141,9 @@ export function GoalDetailsPopoverView({
               </DialogHeader>
               {/* Scrollable content area */}
               {/* pb-4 ensures content can scroll past keyboard on iOS */}
-              <div className="space-y-3 overflow-y-auto flex-1 py-1 pb-4 overscroll-contain">
-                {children}
+              <div className="overflow-y-auto flex-1 py-1 pb-4 overscroll-contain">
+                {/* Center content in a readable max-width column with horizontal padding */}
+                <div className="mx-auto w-full max-w-2xl space-y-3 px-1 sm:px-2">{children}</div>
               </div>
             </DialogContent>
           )}


### PR DESCRIPTION
## Summary

- **Symptom:** The expanded ("Expand") goal-details modal looked unpadded and stretched edge-to-edge on wide/touch viewports.
- **Root cause:** In `GoalDetailsPopoverView`'s `fullScreen` branch, content children (`GoalHeader`, tabs, etc.) had no horizontal constraint. The inner scroll wrapper only applied vertical spacing (`space-y-3`) with no `px`, and the touch path used near full-bleed width (`w-[calc(100vw-16px)] max-w-none`).
- **Fix:** Wrap fullScreen content in both touch (`FullscreenDialogContent`) and mouse (`DialogContent`) sub-branches with a centered `max-w-2xl` column (`mx-auto w-full max-w-2xl space-y-3 px-1 sm:px-2`). Dialog container classes are unchanged; desktop `FixedSizeDialog` and popover paths are untouched.

## Test plan

- [ ] Open a goal's details, click the ⋮ menu → **Expand** (fullscreen).
- [ ] Confirm content is centered with comfortable side padding and a readable width (not stretched edge-to-edge).
- [ ] Check on both a narrow (mobile/touch) and wide (desktop) viewport.
- [ ] Confirm the normal goal details modal and popover are unchanged.


Made with [Cursor](https://cursor.com)