### PR TITLE
feat(webapp): add quarterly goal creation in focus view

### DIFF
--- a/apps/webapp/src/components/molecules/focus/CreateQuarterlyGoalDialog.tsx
+++ b/apps/webapp/src/components/molecules/focus/CreateQuarterlyGoalDialog.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useGoalActions } from '@/hooks/useGoalActions';
+
+export interface CreateQuarterlyGoalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  year: number;
+  quarter: 1 | 2 | 3 | 4;
+  weekNumber: number;
+}
+
+export function CreateQuarterlyGoalDialog({
+  open,
+  onOpenChange,
+  year,
+  quarter,
+  weekNumber,
+}: CreateQuarterlyGoalDialogProps) {
+  const { createQuarterlyGoal } = useGoalActions();
+  const [title, setTitle] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await createQuarterlyGoal({ title: trimmedTitle, year, quarter, weekNumber });
+      onOpenChange(false);
+      setTitle('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Plus className="h-5 w-5 text-primary" />
+            New Quarterly Goal
+          </DialogTitle>
+          <DialogDescription>
+            Add a quarterly goal for Q{quarter}, {year}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="quarterly-goal-title">Goal Text</Label>
+            <Input
+              id="quarterly-goal-title"
+              placeholder="What do you want to achieve this quarter?"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              autoFocus
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!title.trim() || isSubmitting}>
+            {isSubmitting ? 'Creating...' : 'Create Goal'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
@@ -21,6 +21,7 @@ import { History, Loader2, Plus } from 'lucide-react';
 import { DateTime } from 'luxon';
 import { useCallback, useEffect, useState } from 'react';
 
+import { CreateQuarterlyGoalDialog } from '@/components/molecules/focus/CreateQuarterlyGoalDialog';
 import {
   FocusedAdhocGoalsSection,
   FocusedQuarterlyGoalsSection,
@@ -52,6 +53,7 @@ import { getQuarterFromWeek } from '@/lib/date/iso-week';
 export function FocusModeFocusedView() {
   // ── History dialog ─────────────────────────────────────────────────────
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [isCreateQuarterlyGoalOpen, setIsCreateQuarterlyGoalOpen] = useState(false);
 
   // ── Scratchpad ─────────────────────────────────────────────────────────
   const {
@@ -269,6 +271,15 @@ export function FocusModeFocusedView() {
             <FocusedQuarterlyGoalsSection
               goals={focusedViewData.quarterlyGoals}
               onToggleComplete={handleNormalGoalCompleteChange}
+              onAddGoal={() => setIsCreateQuarterlyGoalOpen(true)}
+            />
+
+            <CreateQuarterlyGoalDialog
+              open={isCreateQuarterlyGoalOpen}
+              onOpenChange={setIsCreateQuarterlyGoalOpen}
+              year={year}
+              quarter={quarter}
+              weekNumber={weekNumber}
             />
 
             <FocusedAdhocGoalsSection

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalSection.tsx
@@ -23,6 +23,7 @@ interface FocusedGoalSectionProps {
   count?: number;
   tone?: FocusedGoalSectionTone;
   icon?: ReactNode;
+  action?: ReactNode;
   children: ReactNode;
 }
 
@@ -32,6 +33,7 @@ export function FocusedGoalSection({
   count,
   tone = 'muted',
   icon,
+  action,
   children,
 }: FocusedGoalSectionProps) {
   const styles = toneStyles[tone];
@@ -54,6 +56,7 @@ export function FocusedGoalSection({
             <span className={`text-[10px] font-bold tabular-nums ${styles.text}`}>{count}</span>
           </span>
         )}
+        {action && <div className="ml-auto">{action}</div>}
       </div>
       {children}
     </div>

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { FocusedGoalItem } from '@workspace/backend/convex/bff/focus';
-import { Pin, Star, Target } from 'lucide-react';
+import { Pin, Plus, Star, Target } from 'lucide-react';
 
 import { FocusedGoalListItem } from './FocusedGoalListItem';
 import { FocusedGoalSection } from './FocusedGoalSection';
@@ -9,11 +9,13 @@ import { FocusedGoalSection } from './FocusedGoalSection';
 interface FocusedQuarterlyGoalsSectionProps {
   goals: FocusedGoalItem[];
   onToggleComplete: (goalId: FocusedGoalItem['_id'], isComplete: boolean) => void;
+  onAddGoal?: () => void;
 }
 
 export function FocusedQuarterlyGoalsSection({
   goals,
   onToggleComplete,
+  onAddGoal,
 }: FocusedQuarterlyGoalsSectionProps) {
   return (
     <FocusedGoalSection
@@ -21,6 +23,18 @@ export function FocusedQuarterlyGoalsSection({
       description="Star or pin goals to keep them visible here."
       count={goals.length}
       icon={<Target className="h-3.5 w-3.5 text-muted-foreground" />}
+      action={
+        onAddGoal ? (
+          <button
+            type="button"
+            onClick={onAddGoal}
+            className="h-5 w-5 rounded-full text-muted-foreground hover:bg-accent hover:text-foreground flex items-center justify-center"
+            aria-label="Add quarterly goal"
+          >
+            <Plus className="h-3 w-3" />
+          </button>
+        ) : undefined
+      }
     >
       {goals.length === 0 ? (
         <p className="px-4 py-3 text-sm text-muted-foreground">


### PR DESCRIPTION
Adds a minimal plus trigger in the focus view Quarterly Goals section that opens a ShadCN dialog for creating a new quarterly goal for the current year/quarter/week.

Changes:
- Added CreateQuarterlyGoalDialog using existing ShadCN dialog and goal action hooks.
- Added optional section action support and wired the quarterly goals plus trigger.
- Rendered the dialog from the focus view using current week context.

Verification:
- pnpm typecheck
- pnpm test