### PR TITLE
fix(webapp): restore Popover modal default for Safari date pickers

### DIFF
--- a/apps/webapp/src/app/test/shadcn-modal/page.tsx
+++ b/apps/webapp/src/app/test/shadcn-modal/page.tsx
@@ -217,7 +217,7 @@ export default function ShadcnModalTestPage() {
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label className="text-right">Date</Label>
                 <div className="col-span-3">
-                  <Popover>
+                  <Popover modal>
                     <PopoverTrigger asChild>
                       <Button
                         variant="outline"

--- a/apps/webapp/src/components/DateRangePicker.tsx
+++ b/apps/webapp/src/components/DateRangePicker.tsx
@@ -144,7 +144,7 @@ export function DateRangePicker({
       </Button>
 
       <div className="flex-1">
-        <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <Popover modal open={isOpen} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
             <Button
               variant="outline"

--- a/apps/webapp/src/components/atoms/GoalEditPopover.tsx
+++ b/apps/webapp/src/components/atoms/GoalEditPopover.tsx
@@ -231,7 +231,7 @@ export function GoalEditPopover({
       <div className="space-y-2">
         {/* biome-ignore lint/a11y/noLabelWithoutControl: Label is visually associated with date picker below */}
         <label className="text-sm font-medium text-muted-foreground">Due Date</label>
-        <Popover>
+        <Popover modal>
           <PopoverTrigger asChild>
             <Button
               variant="outline"

--- a/apps/webapp/src/components/molecules/AdhocGoalForm.tsx
+++ b/apps/webapp/src/components/molecules/AdhocGoalForm.tsx
@@ -180,7 +180,7 @@ export function AdhocGoalForm({
 
       <div>
         <Label>Due Date (optional)</Label>
-        <Popover>
+        <Popover modal>
           <PopoverTrigger asChild>
             <Button
               variant="outline"

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditModal.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditModal.tsx
@@ -151,7 +151,7 @@ export function GoalEditModal({ isOpen, goal, onSave, onClose }: GoalEditModalPr
           <div className="space-y-2">
             {/* biome-ignore lint/a11y/noLabelWithoutControl: Label is visually associated with date picker below */}
             <label className="text-sm font-medium">Due Date</label>
-            <Popover>
+            <Popover modal>
               <PopoverTrigger asChild>
                 <Button
                   variant="outline"

--- a/apps/webapp/src/components/molecules/goal-log/GoalLogCreateForm.tsx
+++ b/apps/webapp/src/components/molecules/goal-log/GoalLogCreateForm.tsx
@@ -195,7 +195,7 @@ export function GoalLogCreateForm({
         {/* biome-ignore lint/a11y/noLabelWithoutControl: Label is visually associated with date picker below */}
         <label className="text-sm font-medium text-muted-foreground">Log Date & Time</label>
         <div className="flex gap-2">
-          <Popover>
+          <Popover modal>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
@@ -368,7 +368,7 @@ export function GoalLogEditForm({
         {/* biome-ignore lint/a11y/noLabelWithoutControl: Label is visually associated with date picker below */}
         <label className="text-sm font-medium text-muted-foreground">Log Date & Time</label>
         <div className="flex gap-2">
-          <Popover>
+          <Popover modal>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"

--- a/apps/webapp/src/components/ui/popover.tsx
+++ b/apps/webapp/src/components/ui/popover.tsx
@@ -13,8 +13,10 @@ import { cn } from '@/lib/utils';
  * - 2px border
  * - Glassmorphism with backdrop-blur
  */
-function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+function Popover({ modal = true, ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  // modal=true is required for date pickers (Calendar) to open inside Dialogs on Safari/iOS.
+  // See apps/webapp/src/app/test/shadcn-modal/page.tsx and commit 9b559e3.
+  return <PopoverPrimitive.Root data-slot="popover" modal={modal} {...props} />;
 }
 
 function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {

--- a/apps/webapp/src/components/ui/popover.tsx
+++ b/apps/webapp/src/components/ui/popover.tsx
@@ -13,10 +13,8 @@ import { cn } from '@/lib/utils';
  * - 2px border
  * - Glassmorphism with backdrop-blur
  */
-function Popover({ modal = true, ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
-  // modal=true is required for date pickers (Calendar) to open inside Dialogs on Safari/iOS.
-  // See apps/webapp/src/app/test/shadcn-modal/page.tsx and commit 9b559e3.
-  return <PopoverPrimitive.Root data-slot="popover" modal={modal} {...props} />;
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
 function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {


### PR DESCRIPTION
## Summary

Fixes broken date pickers in Safari (including the "Log Date & Time" picker in goal log forms). Calendar-based date pickers fail to open because Radix Popover requires `modal={true}` when nested inside Dialogs on Safari/iOS.

## Root Cause Analysis

**Symptom:** Date pickers (Popover + Calendar) do not open or appear in Safari — affects Log Date & Time, DateRangePicker, goal due date pickers, etc.

**Root cause:** Commit `b5a37b1` removed `modal={true}` from Popover usages. Radix Popover requires `modal=true` for nested popovers (date pickers inside Dialogs) to work on Safari/iOS due to focus trapping, pointer-events, and portal stacking conflicts between Dialog overlays and Popover content.

This was a previously known issue:
- Original fix: commit `9b559e3` — "date pickers often cannot be opened on iOS in modals unless this is set to true"
- Documented in `apps/webapp/src/app/test/shadcn-modal/page.tsx`

**Why not restore -> UI migration?** Base UI Popover also defaults to `modal={false}`. Migration would not auto-fix this and introduces separate Safari considerations (iOS 26 backdrop CSS). The targeted `modal` prop fix is the standard shadcn recommendation ([shadcn-ui/ui#332](https://github.com/shadcn-ui/ui/issues/332)).

## Fix

Apply `modal` (i.e. `modal={true}`) **only on date picker Popover usages**, not on the shared Popover primitive — avoids the performance overhead of modal mode on unrelated popovers (the reason `b5a37b1` removed it globally).

Updated files:
- `DateRangePicker.tsx`
- `GoalLogCreateForm.tsx` (create + edit forms)
- `GoalEditModal.tsx`
- `AdhocGoalForm.tsx`
- `GoalEditPopover.tsx`
- `app/test/shadcn-modal/page.tsx`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [ ] Open goal details dialog in Safari → expand log form → click "Log Date & Time" → calendar appears
- [ ] Open goal edit modal in Safari → click due date picker → calendar appears
- [ ] Open DateRangePicker on dashboard in Safari → calendar appears
- [ ] Verify date pickers still work in Chrome/Firefox