### PR TITLE
fix(focus): show cross-week urgent goals and index incomplete adhoc reads

### DIFF
--- a/services/backend/convex/bff/focus.spec.ts
+++ b/services/backend/convex/bff/focus.spec.ts
@@ -1,0 +1,101 @@
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { describe, expect, test } from 'vitest';
+
+import { convexTest } from '../../src/util/test';
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+const createTestSession = async (ctx: ReturnType<typeof convexTest>): Promise<SessionId> => {
+  const sessionId = crypto.randomUUID() as SessionId;
+  await ctx.mutation(api.auth.loginAnon, { sessionId });
+  return sessionId;
+};
+
+describe('bff.focus.getFocusedViewData', () => {
+  test('shows incomplete adhoc fire goals from other weeks in urgent section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const pastWeekGoalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Urgent from week 10',
+      year,
+      weekNumber: 10,
+    });
+
+    await ctx.mutation(api.fireGoal.toggleFireStatus, {
+      sessionId,
+      goalId: pastWeekGoalId,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.urgent.map((g) => g._id)).toContain(pastWeekGoalId);
+    expect(data.urgent.find((g) => g._id === pastWeekGoalId)?.weekNumber).toBe(10);
+    expect(data.adhocTasks.map((g) => g._id)).not.toContain(pastWeekGoalId);
+  });
+
+  test('excludes completed fire goals from urgent section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const goalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Completed urgent task',
+      year,
+      weekNumber: 10,
+    });
+
+    await ctx.mutation(api.fireGoal.toggleFireStatus, {
+      sessionId,
+      goalId,
+    });
+
+    await ctx.mutation(api.adhocGoal.updateAdhocGoal, {
+      sessionId,
+      goalId,
+      isComplete: true,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.urgent.map((g) => g._id)).not.toContain(goalId);
+  });
+
+  test('shows incomplete adhoc goals from other weeks in tasks section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const pastWeekGoalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Open task from week 5',
+      year,
+      weekNumber: 5,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.adhocTasks.map((g) => g._id)).toContain(pastWeekGoalId);
+  });
+});

--- a/services/backend/convex/bff/focus.ts
+++ b/services/backend/convex/bff/focus.ts
@@ -117,6 +117,9 @@ async function getQuarterlyGoals(
 }
 
 // ── Urgent Goals ──────────────────────────────────────────────────────────────
+// Focus view Urgent section: all incomplete fire goals for the year.
+// Adhoc fire goals are year-scoped (assignment week is metadata, not visibility).
+// Quarterly/weekly/daily fire goals still require goalStateByWeek for the current week/day.
 
 async function getUrgentGoals(
   ctx: QueryCtx,
@@ -141,14 +144,15 @@ async function getUrgentGoals(
 
   let filtered = goalDocs
     .filter((g) => g !== null)
+    .filter((g) => !g.isComplete)
     .filter((g) => {
       if (g.adhoc) {
-        return g.year === year && g.adhoc.weekNumber === weekNumber;
+        return g.year === year;
       }
       return g.year === year && g.quarter === quarter;
     })
     .filter((g) => g.depth !== 0 || g.adhoc)
-    .filter((g) => !g.isBacklog); // Exclude backlog goals from urgent section
+    .filter((g) => !g.isBacklog);
 
   // Fetch ALL goalStateByWeek entries for the current week in a single indexed query,
   // then filter in memory. Avoids N+1 lookups when the user has many fire goals.
@@ -195,6 +199,8 @@ async function getUrgentGoals(
 }
 
 // ── Adhoc Tasks ───────────────────────────────────────────────────────────────
+// Focus view Tasks section: incomplete adhoc inbox for the year (all weeks).
+// Excludes backlog and fire goals (urgent section owns those).
 
 type AdhocNode = {
   _id: Id<'goals'>;
@@ -226,16 +232,14 @@ async function getAdhocTasksFlattened(
 
   const fireGoalIds = new Set(fireGoals.map((fg) => fg.goalId.toString()));
 
-  const allAdhocGoals = await ctx.db
-    .query('goals')
-    .withIndex('by_user_and_adhoc_year_week', (q) => q.eq('userId', userId).eq('year', year))
-    .collect();
-
-  // Include all incomplete adhoc goals for the year, regardless of assigned week.
-  // Exclude backlog goals and fire goals (urgent section owns those).
-  const adhocGoals = allAdhocGoals.filter(
-    (g) => !g.isComplete && !g.isBacklog && !fireGoalIds.has(g._id.toString())
-  );
+  const adhocGoals = (
+    await ctx.db
+      .query('goals')
+      .withIndex('by_user_and_adhoc_year_and_complete', (q) =>
+        q.eq('userId', userId).eq('year', year).eq('isComplete', false)
+      )
+      .collect()
+  ).filter((g) => !g.isBacklog && !fireGoalIds.has(g._id.toString()));
 
   // Resolve domains
   const domainIds = [

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -314,6 +314,13 @@ export default defineSchema({
     .index('by_user_and_year_and_quarter', ['userId', 'year', 'quarter'])
     .index('by_user_and_year_and_quarter_and_parent', ['userId', 'year', 'quarter', 'parentId'])
     .index('by_user_and_adhoc_year_week', ['userId', 'year', 'adhoc.weekNumber'])
+    // Prefix (userId + year + isComplete) returns incomplete adhoc goals for inbox-style reads.
+    .index('by_user_and_adhoc_year_and_complete', [
+      'userId',
+      'year',
+      'isComplete',
+      'adhoc.weekNumber',
+    ])
     .index('by_user_and_domain', ['userId', 'domainId']),
 
   /**


### PR DESCRIPTION
## Summary
- Fixes Focus view **Urgent** section to show incomplete adhoc fire goals across all weeks in the year (matching the Tasks inbox fix from #68)
- Excludes completed goals from the Urgent section
- Adds `by_user_and_adhoc_year_and_complete` index so Tasks inbox queries skip completed rows at the database layer
- Adds backend tests for cross-week urgent/tasks visibility and completed-goal exclusion

## Query efficiency assessment

**`getUrgentGoals`** — already efficient for its access pattern:
- Starts from `fireGoals` via `by_user` index (typically a small set per user)
- Fetches goal docs by ID (O(fire count), not O(all goals))
- A completion index on `goals` would not help this path because we never scan the goals table for urgent items

**`getAdhocTasksFlattened`** — improved:
- Previously: prefix query on `by_user_and_adhoc_year_week` returned **all** adhoc goals for the year, then filtered `!isComplete` in memory
- Now: `by_user_and_adhoc_year_and_complete` with prefix `userId + year + isComplete=false` returns only incomplete adhoc goals from the index

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (including 3 new `focus.spec.ts` tests)
- [ ] Manual: mark an adhoc goal urgent in a past week, view Focus on a different week — should appear in Urgent, not Tasks
- [ ] Manual: complete an urgent goal — should disappear from Urgent

Made with [Cursor](https://cursor.com)