### PR TITLE
fix(focus): revert year-wide adhoc tasks and show cross-week urgent goals

### DIFF
--- a/services/backend/convex/bff/focus.spec.ts
+++ b/services/backend/convex/bff/focus.spec.ts
@@ -1,0 +1,101 @@
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { describe, expect, test } from 'vitest';
+
+import { convexTest } from '../../src/util/test';
+import { api } from '../_generated/api';
+import schema from '../schema';
+
+const createTestSession = async (ctx: ReturnType<typeof convexTest>): Promise<SessionId> => {
+  const sessionId = crypto.randomUUID() as SessionId;
+  await ctx.mutation(api.auth.loginAnon, { sessionId });
+  return sessionId;
+};
+
+describe('bff.focus.getFocusedViewData', () => {
+  test('shows incomplete adhoc fire goals from other weeks in urgent section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const pastWeekGoalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Urgent from week 10',
+      year,
+      weekNumber: 10,
+    });
+
+    await ctx.mutation(api.fireGoal.toggleFireStatus, {
+      sessionId,
+      goalId: pastWeekGoalId,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.urgent.map((g) => g._id)).toContain(pastWeekGoalId);
+    expect(data.urgent.find((g) => g._id === pastWeekGoalId)?.weekNumber).toBe(10);
+    expect(data.adhocTasks.map((g) => g._id)).not.toContain(pastWeekGoalId);
+  });
+
+  test('excludes completed fire goals from urgent section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const goalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Completed urgent task',
+      year,
+      weekNumber: 10,
+    });
+
+    await ctx.mutation(api.fireGoal.toggleFireStatus, {
+      sessionId,
+      goalId,
+    });
+
+    await ctx.mutation(api.adhocGoal.updateAdhocGoal, {
+      sessionId,
+      goalId,
+      isComplete: true,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.urgent.map((g) => g._id)).not.toContain(goalId);
+  });
+
+  test('excludes adhoc goals from other weeks in tasks section', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const year = 2024;
+
+    const pastWeekGoalId = await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Open task from week 5',
+      year,
+      weekNumber: 5,
+    });
+
+    const data = await ctx.query(api.bff.focus.getFocusedViewData, {
+      sessionId,
+      year,
+      quarter: 1,
+      weekNumber: 20,
+      dayOfWeek: 1,
+    });
+
+    expect(data.adhocTasks.map((g) => g._id)).not.toContain(pastWeekGoalId);
+  });
+});

--- a/services/backend/convex/bff/focus.ts
+++ b/services/backend/convex/bff/focus.ts
@@ -48,7 +48,7 @@ export const getFocusedViewData = query({
     const [urgent, quarterlyGoals, adhocTasks] = await Promise.all([
       getUrgentGoals(ctx, { userId, year, quarter, weekNumber, dayOfWeek }),
       getQuarterlyGoals(ctx, { userId, year, quarter, weekNumber }),
-      getAdhocTasksFlattened(ctx, { userId, year }),
+      getAdhocTasksFlattened(ctx, { userId, year, weekNumber }),
     ]);
 
     return { urgent, quarterlyGoals, adhocTasks };
@@ -117,6 +117,9 @@ async function getQuarterlyGoals(
 }
 
 // ── Urgent Goals ──────────────────────────────────────────────────────────────
+// Focus view Urgent section: all incomplete fire goals for the year.
+// Adhoc fire goals are year-scoped (assignment week is metadata, not visibility).
+// Quarterly/weekly/daily fire goals still require goalStateByWeek for the current week/day.
 
 async function getUrgentGoals(
   ctx: QueryCtx,
@@ -141,14 +144,15 @@ async function getUrgentGoals(
 
   let filtered = goalDocs
     .filter((g) => g !== null)
+    .filter((g) => !g.isComplete)
     .filter((g) => {
       if (g.adhoc) {
-        return g.year === year && g.adhoc.weekNumber === weekNumber;
+        return g.year === year;
       }
       return g.year === year && g.quarter === quarter;
     })
     .filter((g) => g.depth !== 0 || g.adhoc)
-    .filter((g) => !g.isBacklog); // Exclude backlog goals from urgent section
+    .filter((g) => !g.isBacklog);
 
   // Fetch ALL goalStateByWeek entries for the current week in a single indexed query,
   // then filter in memory. Avoids N+1 lookups when the user has many fire goals.
@@ -195,6 +199,9 @@ async function getUrgentGoals(
 }
 
 // ── Adhoc Tasks ───────────────────────────────────────────────────────────────
+// Focus view Tasks section: incomplete adhoc goals for the current week only.
+// Past-week tasks stay in their assigned week until pulled forward (see moveGoalsFromWeek).
+// Excludes backlog and fire goals (urgent section owns those).
 
 type AdhocNode = {
   _id: Id<'goals'>;
@@ -214,9 +221,10 @@ async function getAdhocTasksFlattened(
   args: {
     userId: Id<'users'>;
     year: number;
+    weekNumber: number;
   }
 ): Promise<FocusedGoalItem[]> {
-  const { userId, year } = args;
+  const { userId, year, weekNumber } = args;
 
   // Get fire goals so we can exclude them from adhoc tasks
   const fireGoals = await ctx.db
@@ -226,16 +234,14 @@ async function getAdhocTasksFlattened(
 
   const fireGoalIds = new Set(fireGoals.map((fg) => fg.goalId.toString()));
 
-  const allAdhocGoals = await ctx.db
-    .query('goals')
-    .withIndex('by_user_and_adhoc_year_week', (q) => q.eq('userId', userId).eq('year', year))
-    .collect();
-
-  // Include all incomplete adhoc goals for the year, regardless of assigned week.
-  // Exclude backlog goals and fire goals (urgent section owns those).
-  const adhocGoals = allAdhocGoals.filter(
-    (g) => !g.isComplete && !g.isBacklog && !fireGoalIds.has(g._id.toString())
-  );
+  const adhocGoals = (
+    await ctx.db
+      .query('goals')
+      .withIndex('by_user_and_adhoc_year_week', (q) =>
+        q.eq('userId', userId).eq('year', year).eq('adhoc.weekNumber', weekNumber)
+      )
+      .collect()
+  ).filter((g) => !g.isComplete && !g.isBacklog && !fireGoalIds.has(g._id.toString()));
 
   // Resolve domains
   const domainIds = [
@@ -305,13 +311,6 @@ async function getAdhocTasksFlattened(
       flattenNode(child, indentLevel + 1, node.title);
     }
   }
-
-  rootGoals.sort((a, b) => {
-    const weekA = a.adhoc?.weekNumber ?? 0;
-    const weekB = b.adhoc?.weekNumber ?? 0;
-    if (weekA !== weekB) return weekA - weekB;
-    return 0;
-  });
 
   for (const root of rootGoals) {
     flattenNode(root, 0);


### PR DESCRIPTION
## Summary
- Reverts PR #68's year-wide Tasks query — Focus Tasks again shows only incomplete adhoc goals for the **current week**
- Extends the Urgent section to surface incomplete adhoc fire goals from any week in the year (and excludes completed fire goals)
- Adds `focus.spec.ts` coverage for both behaviors

## Why
PR #68 treated past-week incomplete adhoc goals as accidentally hidden. They are intentionally week-scoped: `adhoc.weekNumber` is where the task lives until the user explicitly pulls it forward via **Pull from Previous Week**. Showing the entire year's backlog in Focus flooded users with stale tasks.

Urgent (fire) goals are different — marking something urgent means it should be visible regardless of assigned week.

## Test plan
- [ ] Create an incomplete adhoc task in a past week; confirm it does **not** appear in Focus Tasks on the current week
- [ ] Pull from previous week; confirm pulled adhoc tasks **do** appear in Focus Tasks
- [ ] Mark a past-week adhoc task as urgent; confirm it appears in Urgent, not Tasks
- [ ] Complete an urgent task; confirm it disappears from Urgent
- [x] `pnpm test focus.spec` passes


Made with [Cursor](https://cursor.com)