### PR TITLE
fix(webapp): prevent pasted code blocks from overflowing goal details modal

### DIFF
--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -81,7 +81,12 @@ export function GoalDetailsContent({
           </div>
         )}
 
-        <div className={cn('overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30', className)}>
+        <div
+          className={cn(
+            'min-w-0 overflow-x-hidden overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30',
+            className
+          )}
+        >
           {hasInteractiveFeatures ? (
             <InteractiveHTML
               html={details}

--- a/apps/webapp/src/components/ui/rich-text-editor.module.css
+++ b/apps/webapp/src/components/ui/rich-text-editor.module.css
@@ -14,6 +14,16 @@
  */
 
 /* ==========================================================================
+   ROOT CONTAINER
+   ========================================================================== */
+
+/* Allow prose content to shrink inside flex/grid parents */
+.prose {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* ==========================================================================
    LISTS (Ordered & Unordered)
    ========================================================================== */
 
@@ -398,6 +408,16 @@
   font-size: 0.875em !important;
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace !important;
   word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+  max-width: 100% !important;
+}
+
+/* Inline code only — pasted styled content can force block/nowrap and blow out containers */
+.prose :global(:not(pre) > code) {
+  display: inline !important;
+  white-space: pre-wrap !important;
+  box-decoration-break: clone !important;
+  -webkit-box-decoration-break: clone !important;
 }
 
 /* Code blocks */
@@ -406,6 +426,8 @@
   margin-bottom: 0.75em !important;
   padding: 0.75rem 1rem !important;
   border-radius: 0.375rem !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
   overflow-x: auto !important;
   font-size: 0.85em !important;
   line-height: 1.5 !important;
@@ -413,6 +435,7 @@
 
 /* Code inside pre - reset inline styles */
 .prose :global(pre code) {
+  display: block !important;
   padding: 0 !important;
   border-radius: 0 !important;
   background: transparent !important;
@@ -420,6 +443,7 @@
   color: inherit !important;
   word-break: normal !important;
   white-space: pre !important;
+  max-width: none !important;
 }
 
 /* ==========================================================================

--- a/apps/webapp/src/components/ui/rich-text-editor.tsx
+++ b/apps/webapp/src/components/ui/rich-text-editor.tsx
@@ -401,7 +401,7 @@ export function RichTextEditor({
     editorProps: {
       attributes: {
         class: cn(
-          'prose prose-sm dark:prose-invert text-sm max-w-none focus:outline-none min-h-[150px] h-full p-3 rounded-md border break-words [word-break:break-word]',
+          'prose prose-sm dark:prose-invert text-sm max-w-none focus:outline-none min-h-[150px] h-full min-w-0 p-3 rounded-md border break-words [word-break:break-word] overflow-x-hidden',
           styles.prose,
           className
         ),

--- a/apps/webapp/src/components/ui/safe-html.tsx
+++ b/apps/webapp/src/components/ui/safe-html.tsx
@@ -130,7 +130,7 @@ export function SafeHTML({
   return (
     <div
       className={cn(
-        'prose prose-sm dark:prose-invert max-w-none break-words overflow-wrap-anywhere',
+        'prose prose-sm dark:prose-invert max-w-none break-words overflow-wrap-anywhere min-w-0 overflow-hidden',
         styles.prose,
         className
       )}


### PR DESCRIPTION
## Summary
- Constrain pasted `code` and `pre` elements in shared prose styles so long or styled clipboard content cannot expand past the modal width
- Add `min-w-0` and horizontal overflow guards to goal details containers, `SafeHTML`, and the rich text editor for consistent layout in flex dialogs

## Test plan
- [ ] Open a goal details modal and paste styled content containing inline `code` with long unbroken strings — content should wrap inside the modal
- [ ] Paste a multi-line code block (`<pre><code>`) — block should scroll horizontally within the container instead of breaking modal layout
- [ ] Verify goal details view mode (read-only) and edit mode (rich text editor) both respect container width
- [ ] Confirm expand-to-full-view dialog still scrolls correctly for long details


Made with [Cursor](https://cursor.com)