### PR TITLE
fix(ui): destructive button text color in dark mode

### DIFF
--- a/apps/webapp/src/components/UserMenu.tsx
+++ b/apps/webapp/src/components/UserMenu.tsx
@@ -103,11 +103,7 @@ function _renderLogoutConfirmDialog(
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleLogout}
-            disabled={isLoggingOut}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
+          <AlertDialogAction onClick={handleLogout} disabled={isLoggingOut} variant="destructive">
             {isLoggingOut ? 'Logging out...' : 'Log out'}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/apps/webapp/src/components/organisms/GoalDeletePreviewDialog.tsx
+++ b/apps/webapp/src/components/organisms/GoalDeletePreviewDialog.tsx
@@ -223,7 +223,7 @@ export const GoalDeletePreviewDialog = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onDeleteGoals} className="bg-red-500 hover:bg-red-600">
+          <AlertDialogAction onClick={onDeleteGoals} variant="destructive">
             Delete
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/apps/webapp/src/components/organisms/focus/ScratchpadHistoryDialog.tsx
+++ b/apps/webapp/src/components/organisms/focus/ScratchpadHistoryDialog.tsx
@@ -296,10 +296,7 @@ export function ScratchpadHistoryDialog({ open, onOpenChange }: ScratchpadHistor
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
+            <AlertDialogAction onClick={handleDeleteConfirm} variant="destructive">
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/webapp/src/components/ui/alert-dialog.tsx
+++ b/apps/webapp/src/components/ui/alert-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import { type VariantProps } from 'class-variance-authority';
 import type * as React from 'react';
 
 import { buttonVariants } from '@/components/ui/button';
@@ -118,9 +119,15 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  variant,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
-  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> & VariantProps<typeof buttonVariants>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants({ variant }), className)}
+      {...props}
+    />
+  );
 }
 
 function AlertDialogCancel({

--- a/apps/webapp/src/modules/profile/NameEditForm.tsx
+++ b/apps/webapp/src/modules/profile/NameEditForm.tsx
@@ -346,7 +346,7 @@ export function NameEditForm() {
             <AlertDialogAction
               onClick={handleDisconnect}
               disabled={disconnectDialog.isDisconnecting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              variant="destructive"
             >
               {disconnectDialog.isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
             </AlertDialogAction>


### PR DESCRIPTION
The destructive buttons in alert dialogs used `text-destructive-foreground` which resolves to black in dark mode, making text unreadable on the light-red destructive background.

## Changes
- Added `variant` prop to `AlertDialogAction` component so callers can use `variant="destructive"` instead of manually specifying classes
- Updated all destructive AlertDialogAction usages to use `variant="destructive"` (which applies `text-white` correctly in both modes)
- Removed manual `bg-destructive text-destructive-foreground` class overrides

### Files changed
- `apps/webapp/src/components/ui/alert-dialog.tsx` — added variant prop
- `apps/webapp/src/components/UserMenu.tsx` — logout button
- `apps/webapp/src/components/organisms/GoalDeletePreviewDialog.tsx` — delete goals button
- `apps/webapp/src/components/organisms/focus/ScratchpadHistoryDialog.tsx` — delete scratchpad button
- `apps/webapp/src/modules/profile/NameEditForm.tsx` — disconnect button