### PR TITLE
fix(initiatives): open initiative selector in Safari inside dialogs

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeSelector.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.tsx
@@ -59,7 +59,7 @@ export function InitiativeSelector({
 
   return (
     <div className="space-y-1">
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover modal open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
             type="button"


### PR DESCRIPTION
## Summary
- Fixes Safari bug where the initiative tag/search combobox does not open inside goal detail dialogs (e.g. adhoc goal popover via `FixedSizeDialog`).
- Adds `modal` to `InitiativeSelector`'s Radix `Popover`, matching the established pattern used by `DatePicker`, `GoalEditModal`, and other dialog-nested popovers.

## Root cause
Safari's dialog focus trap closes non-modal nested popovers immediately on open. The codebase already documents this pattern (`GoalEditPopover`, `GoalDetailsPopoverView`).

## Context
Rebased on current `master` after the initiatives feature merge (#77). The Safari fix was not included in that merge.

## Test plan
- [ ] Open a goal in Safari (desktop or iOS) via the details dialog / adhoc popover
- [ ] Click "Tag to an initiative..." combobox — search list should open
- [ ] Search and select an initiative — selection should persist
- [ ] Verify Chrome/Firefox behavior unchanged
- [ ] Verify initiative selector still works outside dialogs (e.g. goal edit forms)


Made with [Cursor](https://cursor.com)