### PR TITLE
fix(initiatives): persist goal initiative tag in details modal

### DIFF
--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/StandaloneGoalModal.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/StandaloneGoalModal.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react';
+import type { Id } from '@workspace/backend/convex/_generated/dataModel';
+import { useQuery } from 'convex/react';
+import type { SessionId } from 'convex-helpers/server/sessions';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { StandaloneGoalModal } from './StandaloneGoalModal';
+import { GoalInitiativeField } from '../view/components/GoalInitiativeField';
+
+import { useGoalContext } from '@/contexts/GoalContext';
+import { useInitiatives } from '@/hooks/useInitiatives';
+import { useSession } from '@/modules/auth/useSession';
+
+vi.mock('convex/react', () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/useSession', () => ({
+  useSession: vi.fn(),
+}));
+
+vi.mock('@/hooks/useInitiatives', () => ({
+  useInitiatives: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWeek', () => ({
+  WeekProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+vi.mock('./StandardGoalPopoverContent', () => ({
+  StandardGoalPopoverContent: function MockStandardGoalPopoverContent() {
+    const { goal } = useGoalContext();
+    return (
+      <GoalInitiativeField
+        selectedInitiativeId={goal.initiativeId ?? null}
+        onInitiativeChange={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+  },
+}));
+
+vi.mock('./AdhocGoalPopoverContent', () => ({
+  AdhocGoalPopoverContent: () => null,
+}));
+
+const SESSION_ID = 'session-test' as SessionId;
+const GOAL_ID = 'goals:test' as Id<'goals'>;
+const INITIATIVE_ID = 'initiatives:alpha' as Id<'initiatives'>;
+
+const initiatives = [
+  {
+    _id: INITIATIVE_ID,
+    _creationTime: 0,
+    userId: 'users:test' as Id<'users'>,
+    title: 'Q1 Launch',
+    startDate: 1_700_000_000_000,
+    description: undefined,
+    endDate: undefined,
+  },
+];
+
+const weekData = {
+  weekLabel: 'Week 1',
+  weekNumber: 1,
+  mondayDate: 'Jan 1',
+  days: [],
+  tree: {
+    quarterlyGoals: [],
+    weekNumber: 1,
+    allGoals: [],
+  },
+};
+
+function makeGoalDetails(initiativeId?: Id<'initiatives'>) {
+  return {
+    _id: GOAL_ID,
+    _creationTime: 0,
+    title: 'Tagged Goal',
+    isComplete: false,
+    isBacklog: false,
+    depth: 0,
+    year: 2024,
+    quarter: 1,
+    children: [],
+    initiativeId,
+  };
+}
+
+function mockConvexQueries(goalDetails: ReturnType<typeof makeGoalDetails> | null) {
+  vi.mocked(useQuery).mockImplementation(((_query, args) => {
+    if (args === 'skip') return undefined;
+    if (args && typeof args === 'object' && 'goalId' in args) {
+      return goalDetails;
+    }
+    if (args && typeof args === 'object' && 'weekNumber' in args) {
+      return weekData;
+    }
+    return undefined;
+  }) as typeof useQuery);
+}
+
+function renderModal() {
+  return render(
+    <StandaloneGoalModal
+      open
+      onOpenChange={vi.fn()}
+      goalId={GOAL_ID}
+      goalCategory="standard"
+      year={2024}
+      quarter={1}
+      weekNumber={1}
+    />
+  );
+}
+
+describe('StandaloneGoalModal initiative display', () => {
+  beforeEach(() => {
+    vi.mocked(useSession).mockReturnValue({ sessionId: SESSION_ID } as ReturnType<
+      typeof useSession
+    >);
+    vi.mocked(useInitiatives).mockReturnValue({
+      initiatives,
+      createInitiative: vi.fn(),
+      updateInitiative: vi.fn(),
+      deleteInitiative: vi.fn(),
+      isCreating: false,
+      isUpdating: false,
+      isDeleting: false,
+    });
+  });
+
+  it('passes initiativeId from getGoalDetails through GoalProvider to the initiative combobox', () => {
+    mockConvexQueries(makeGoalDetails(INITIATIVE_ID));
+
+    renderModal();
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Q1 Launch');
+    expect(screen.queryByText('Tag to an initiative...')).not.toBeInTheDocument();
+  });
+
+  it('shows placeholder when getGoalDetails omits initiativeId', () => {
+    mockConvexQueries(makeGoalDetails(undefined));
+
+    renderModal();
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Tag to an initiative...');
+  });
+});

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalInitiativeField.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalInitiativeField.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react';
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoalInitiativeField } from './GoalInitiativeField';
+
+import { useInitiatives } from '@/hooks/useInitiatives';
+import { useSession } from '@/modules/auth/useSession';
+
+vi.mock('@/hooks/useInitiatives', () => ({
+  useInitiatives: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/useSession', () => ({
+  useSession: vi.fn(),
+}));
+
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+const SESSION_ID = 'session-test' as SessionId;
+const INITIATIVE_A_ID = 'initiatives:alpha' as Id<'initiatives'>;
+const INITIATIVE_B_ID = 'initiatives:beta' as Id<'initiatives'>;
+
+function makeInitiative(
+  overrides: Partial<Doc<'initiatives'>> & Pick<Doc<'initiatives'>, '_id' | 'title' | 'startDate'>
+): Doc<'initiatives'> {
+  return {
+    _creationTime: 0,
+    userId: 'users:test' as Doc<'initiatives'>['userId'],
+    description: undefined,
+    endDate: undefined,
+    ...overrides,
+  };
+}
+
+const initiatives = [
+  makeInitiative({
+    _id: INITIATIVE_A_ID,
+    title: 'Q1 Launch',
+    startDate: 1_700_000_000_000,
+  }),
+  makeInitiative({
+    _id: INITIATIVE_B_ID,
+    title: 'Platform Hardening',
+    startDate: 1_700_100_000_000,
+  }),
+];
+
+describe('GoalInitiativeField', () => {
+  it('shows the tagged initiative title in the combobox when selectedInitiativeId is set', () => {
+    vi.mocked(useSession).mockReturnValue({ sessionId: SESSION_ID } as ReturnType<
+      typeof useSession
+    >);
+    vi.mocked(useInitiatives).mockReturnValue({
+      initiatives,
+      createInitiative: vi.fn(),
+      updateInitiative: vi.fn(),
+      deleteInitiative: vi.fn(),
+      isCreating: false,
+      isUpdating: false,
+      isDeleting: false,
+    });
+
+    render(
+      <GoalInitiativeField
+        selectedInitiativeId={INITIATIVE_A_ID}
+        onInitiativeChange={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Q1 Launch');
+    expect(screen.queryByText('Tag to an initiative...')).not.toBeInTheDocument();
+  });
+
+  it('shows placeholder when selectedInitiativeId is null', () => {
+    vi.mocked(useSession).mockReturnValue({ sessionId: SESSION_ID } as ReturnType<
+      typeof useSession
+    >);
+    vi.mocked(useInitiatives).mockReturnValue({
+      initiatives,
+      createInitiative: vi.fn(),
+      updateInitiative: vi.fn(),
+      deleteInitiative: vi.fn(),
+      isCreating: false,
+      isUpdating: false,
+      isDeleting: false,
+    });
+
+    render(
+      <GoalInitiativeField
+        selectedInitiativeId={null}
+        onInitiativeChange={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Tag to an initiative...');
+  });
+
+  it('updates displayed initiative when selectedInitiativeId prop changes', () => {
+    vi.mocked(useSession).mockReturnValue({ sessionId: SESSION_ID } as ReturnType<
+      typeof useSession
+    >);
+    vi.mocked(useInitiatives).mockReturnValue({
+      initiatives,
+      createInitiative: vi.fn(),
+      updateInitiative: vi.fn(),
+      deleteInitiative: vi.fn(),
+      isCreating: false,
+      isUpdating: false,
+      isDeleting: false,
+    });
+
+    const { rerender } = render(
+      <GoalInitiativeField
+        selectedInitiativeId={null}
+        onInitiativeChange={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Tag to an initiative...');
+
+    rerender(
+      <GoalInitiativeField
+        selectedInitiativeId={INITIATIVE_B_ID}
+        onInitiativeChange={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Platform Hardening');
+  });
+});

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalInitiativeField.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalInitiativeField.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Id } from '@workspace/backend/convex/_generated/dataModel';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { InitiativeSelector } from '@/components/atoms/InitiativeSelector';
 import { toast } from '@/components/ui/use-toast';
@@ -27,15 +27,21 @@ export function GoalInitiativeField({
   const { sessionId } = useSession();
   const { initiatives } = useInitiatives(sessionId);
   const [isSaving, setIsSaving] = useState(false);
+  const [displayedInitiativeId, setDisplayedInitiativeId] = useState(selectedInitiativeId);
+
+  useEffect(() => {
+    setDisplayedInitiativeId(selectedInitiativeId);
+  }, [selectedInitiativeId]);
 
   // fallow-ignore-next-line complexity
   const handleChange = async (initiativeId: string | null) => {
     if (disabled || isSaving) return;
-    if (initiativeId === selectedInitiativeId) return;
+    if (initiativeId === displayedInitiativeId) return;
 
     setIsSaving(true);
     try {
       await onInitiativeChange(initiativeId as Id<'initiatives'> | null);
+      setDisplayedInitiativeId(initiativeId as Id<'initiatives'> | null);
       const initiative = initiatives.find((item) => item._id === initiativeId);
       toast({
         title: initiativeId ? 'Initiative updated' : 'Initiative removed',
@@ -61,7 +67,7 @@ export function GoalInitiativeField({
       <label className="text-sm font-medium">Initiative</label>
       <InitiativeSelector
         initiatives={initiatives}
-        selectedInitiativeId={selectedInitiativeId}
+        selectedInitiativeId={displayedInitiativeId}
         onInitiativeChange={handleChange}
         placeholder="Tag to an initiative..."
         className="w-full"

--- a/services/backend/convex/dashboard.ts
+++ b/services/backend/convex/dashboard.ts
@@ -1283,6 +1283,7 @@ export const getGoalDetails = query({
       grandParentTitle,
       grandParentId,
       domainId: goal.domainId,
+      initiativeId: goal.initiativeId,
       year: goal.year,
       quarter: goal.quarter,
       adhoc: goal.adhoc,

--- a/services/backend/convex/initiative.spec.ts
+++ b/services/backend/convex/initiative.spec.ts
@@ -206,6 +206,40 @@ describe('initiative', () => {
     expect(daily?.initiativeId).toBe(initiativeId);
   });
 
+  test('getGoalDetails returns initiativeId after tagging', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const initiativeId = await ctx.mutation(api.initiative.createInitiative, {
+      sessionId,
+      title: 'Details Query Test',
+      startDate: 1_700_000_000_000,
+      endDate: 1_700_500_000_000,
+    });
+
+    const quarterlyGoalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Quarterly',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    await ctx.mutation(api.dashboard.updateQuarterlyGoalTitle, {
+      sessionId,
+      goalId: quarterlyGoalId,
+      title: 'Quarterly',
+      initiativeId,
+    });
+
+    const details = await ctx.query(api.dashboard.getGoalDetails, {
+      sessionId,
+      goalId: quarterlyGoalId,
+    });
+
+    expect(details?.initiativeId).toBe(initiativeId);
+  });
+
   test('untagging with null clears initiativeId on descendants', async () => {
     const ctx = convexTest(schema);
     const sessionId = await createTestSession(ctx);


### PR DESCRIPTION
## Summary
- Fixes goal initiative tagging appearing not to save when opened via `StandaloneGoalModal` (focus view, initiative details, breadcrumbs).
- `getGoalDetails` now returns `initiativeId` so the goal context updates after mutation.
- `GoalInitiativeField` keeps the selector in sync optimistically after a successful save (covers quick-view modals with static goal props).

## Root cause
The save mutation was succeeding, but `getGoalDetails` omitted `initiativeId` from its response. `StandaloneGoalModal` feeds that query into `GoalProvider`, so the initiative selector always showed empty after selection.

## Test plan
- [ ] Open a goal from Focus view → tag to an initiative → selection should persist in the modal
- [ ] Close and reopen the same goal → initiative tag should still show
- [ ] Untag (select None) → should clear and persist
- [ ] Verify adhoc and structured goals
- [ ] Cmd+K quick view: tag initiative and confirm selector stays selected


Made with [Cursor](https://cursor.com)