### PR TITLE
feat(ui): click-to-edit goal title and details

### DIFF
--- a/apps/webapp/src/components/molecules/focus/AdhocGoalQuickViewModal.tsx
+++ b/apps/webapp/src/components/molecules/focus/AdhocGoalQuickViewModal.tsx
@@ -17,6 +17,7 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../goal-details-popover/view/components';
 
 import { GoalStatusIcons } from '@/components/atoms/GoalStatusIcons';
@@ -203,6 +204,7 @@ function AdhocGoalQuickViewContent({
   const { sessionId } = useSession();
   const { updateAdhocGoal, deleteAdhocGoal, createAdhocGoal } = useAdhocGoals(sessionId);
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const isComplete = goal.isComplete;
 
   /**
@@ -358,6 +360,7 @@ function AdhocGoalQuickViewContent({
                 onToggleBacklog={handleToggleBacklog}
               />
             }
+            onTitleClick={onTitleClick}
           />
 
           {adhocGoalProp.domain && (
@@ -384,17 +387,14 @@ function AdhocGoalQuickViewContent({
             </TabsList>
 
             <TabsContent value="details" className="mt-4">
-              {goal.details && (
-                <>
-                  <GoalDetailsSection
-                    title={goal.title}
-                    details={goal.details}
-                    onDetailsChange={handleDetailsChange}
-                    showSeparator={false}
-                  />
-                  <Separator className="my-4" />
-                </>
-              )}
+              <GoalDetailsSection
+                title={goal.title}
+                details={goal.details ?? ''}
+                onDetailsChange={handleDetailsChange}
+                showSeparator={false}
+                onEditClick={onEditClick}
+              />
+              <Separator className="my-4" />
 
               {/* Sub-tasks section */}
               <AdhocSubGoalsList

--- a/apps/webapp/src/components/molecules/focus/GoalQuickViewModal.tsx
+++ b/apps/webapp/src/components/molecules/focus/GoalQuickViewModal.tsx
@@ -19,6 +19,7 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../goal-details-popover/view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -125,6 +126,7 @@ function GoalQuickViewContentInternal({
   const { weekNumber, year, quarter, createWeeklyGoalOptimistic, createDailyGoalOptimistic } =
     useWeek();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const isComplete = goal.isComplete;
 
   // State for creating child goals
@@ -260,6 +262,7 @@ function GoalQuickViewContentInternal({
             onToggleComplete={handleToggleComplete}
             statusControls={<GoalStatusIcons goalId={goal._id} />}
             actionMenu={<GoalActionMenuNew onSave={handleSave} goalType={resolveGoalType(goal)} />}
+            onTitleClick={onTitleClick}
           />
 
           {isComplete && goal.completedAt && <GoalCompletionDate completedAt={goal.completedAt} />}
@@ -280,14 +283,13 @@ function GoalQuickViewContentInternal({
             </TabsList>
 
             <TabsContent value="details" className="mt-4">
-              {goal.details && (
-                <GoalDetailsSection
-                  title={goal.title}
-                  details={goal.details}
-                  onDetailsChange={handleDetailsChange}
-                  showSeparator={false}
-                />
-              )}
+              <GoalDetailsSection
+                title={goal.title}
+                details={goal.details ?? ''}
+                onDetailsChange={handleDetailsChange}
+                showSeparator={false}
+                onEditClick={onEditClick}
+              />
 
               {/* Weekly Goals section for quarterly goals */}
               {isQuarterlyGoal && (

--- a/apps/webapp/src/components/molecules/focus/InitiativeDetailsDialog.tsx
+++ b/apps/webapp/src/components/molecules/focus/InitiativeDetailsDialog.tsx
@@ -233,7 +233,13 @@ export function InitiativeDetailsDialog({
           <FixedSizeDialogTitle className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 min-w-0">
               <Flag className="h-4 w-4 text-primary flex-shrink-0" />
-              <span className="truncate">{initiative.title}</span>
+              <button
+                type="button"
+                onClick={() => onEdit(initiative)}
+                className="truncate hover:text-primary transition-colors cursor-pointer text-left"
+              >
+                {initiative.title}
+              </button>
               {titleCountLabel && (
                 <span className="text-xs font-normal text-muted-foreground">
                   ({titleCountLabel})
@@ -263,9 +269,13 @@ export function InitiativeDetailsDialog({
                 </span>
               </div>
               {initiative.description && (
-                <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                <button
+                  type="button"
+                  onClick={() => onEdit(initiative)}
+                  className="text-sm text-muted-foreground whitespace-pre-wrap text-left hover:text-foreground transition-colors cursor-pointer w-full"
+                >
                   {initiative.description}
-                </p>
+                </button>
               )}
               {openWorkSummary && openWorkSummary.totalOpen > 0 && (
                 <p className="text-xs text-muted-foreground">

--- a/apps/webapp/src/components/molecules/focus/InitiativeDetailsDialog.tsx
+++ b/apps/webapp/src/components/molecules/focus/InitiativeDetailsDialog.tsx
@@ -268,13 +268,21 @@ export function InitiativeDetailsDialog({
                   {badge.label}
                 </span>
               </div>
-              {initiative.description && (
+              {initiative.description ? (
                 <button
                   type="button"
                   onClick={() => onEdit(initiative)}
                   className="text-sm text-muted-foreground whitespace-pre-wrap text-left hover:text-foreground transition-colors cursor-pointer w-full"
                 >
                   {initiative.description}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onEdit(initiative)}
+                  className="text-sm text-muted-foreground text-left hover:text-foreground hover:bg-muted/50 rounded-md px-0 py-1 transition-colors cursor-pointer w-full"
+                >
+                  No description — click to add
                 </button>
               )}
               {openWorkSummary && openWorkSummary.totalOpen > 0 && (

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopover.tsx
@@ -16,6 +16,7 @@ import {
   GoalHeader,
   useGoalDisplayContext,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -149,6 +150,7 @@ function AdhocGoalPopoverContentInner({
 }: AdhocGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
 
@@ -171,6 +173,7 @@ function AdhocGoalPopoverContentInner({
           />
         }
         statusControls={<GoalStatusIcons goalId={goal._id} />}
+        onTitleClick={onTitleClick}
       />
 
       {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -192,14 +195,13 @@ function AdhocGoalPopoverContentInner({
 
         {/* overflow-y-auto allows Details content to scroll if it overflows */}
         <TabsContent value="details" className="mt-4 overflow-y-auto">
-          {goal.details && (
-            <GoalDetailsSection
-              title={goal.title}
-              details={goal.details}
-              onDetailsChange={handleDetailsChange}
-              showSeparator={false}
-            />
-          )}
+          <GoalDetailsSection
+            title={goal.title}
+            details={goal.details ?? ''}
+            onDetailsChange={handleDetailsChange}
+            showSeparator={false}
+            onEditClick={onEditClick}
+          />
 
           {/* Sub-tasks section */}
           {(subGoals !== undefined || onCreateChild) && (

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopoverContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopoverContent.tsx
@@ -26,6 +26,7 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 
 import { GoalStatusIcons } from '@/components/atoms/GoalStatusIcons';
@@ -275,6 +276,7 @@ function AdhocGoalPopoverContentInner({
 }: AdhocGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { handleNestedActiveChange } = useDialogEscapeHandler();
 
   return (
@@ -294,6 +296,7 @@ function AdhocGoalPopoverContentInner({
             />
           }
           statusControls={<GoalStatusIcons goalId={goal._id} />}
+          onTitleClick={onTitleClick}
         />
 
         {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -321,14 +324,13 @@ function AdhocGoalPopoverContentInner({
 
           {/* overflow-y-auto allows Details content to scroll if it overflows */}
           <TabsContent value="details" className="mt-4 overflow-y-auto">
-            {goal.details && (
-              <GoalDetailsSection
-                title={goal.title}
-                details={goal.details}
-                onDetailsChange={onDetailsChange}
-                showSeparator={false}
-              />
-            )}
+            <GoalDetailsSection
+              title={goal.title}
+              details={goal.details ?? ''}
+              onDetailsChange={onDetailsChange}
+              showSeparator={false}
+              onEditClick={onEditClick}
+            />
 
             <AdhocSubGoalsList
               subGoals={subGoals}

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/DailyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/DailyGoalPopover.tsx
@@ -17,6 +17,7 @@ import {
   GoalInitiativeField,
   useGoalDisplayContext,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -111,6 +112,7 @@ function DailyGoalPopoverContentInner({
 }: DailyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter } = useWeek();
@@ -134,6 +136,7 @@ function DailyGoalPopoverContentInner({
         onToggleComplete={onToggleComplete}
         statusControls={<GoalStatusIcons goalId={goal._id} />}
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Daily} />}
+        onTitleClick={onTitleClick}
       />
 
       {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -159,14 +162,13 @@ function DailyGoalPopoverContentInner({
 
         {/* overflow-y-auto allows Details content to scroll if it overflows */}
         <TabsContent value="details" className="mt-4 overflow-y-auto">
-          {goal.details && (
-            <GoalDetailsSection
-              title={goal.title}
-              details={goal.details}
-              onDetailsChange={handleDetailsChange}
-              showSeparator={false}
-            />
-          )}
+          <GoalDetailsSection
+            title={goal.title}
+            details={goal.details ?? ''}
+            onDetailsChange={handleDetailsChange}
+            showSeparator={false}
+            onEditClick={onEditClick}
+          />
 
           {additionalContent && (
             <>

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPopover.tsx
@@ -16,6 +16,7 @@ import {
   GoalStatusIndicators,
   useGoalDisplayContext,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -164,6 +165,7 @@ function QuarterlyGoalPopoverContentInner({
 }: QuarterlyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter, weekNumber } = useWeek();
@@ -193,6 +195,7 @@ function QuarterlyGoalPopoverContentInner({
           </div>
         }
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Quarterly} />}
+        onTitleClick={onTitleClick}
       />
 
       <GoalStatusIndicators isStarred={isStarred} isPinned={isPinned} />
@@ -212,14 +215,13 @@ function QuarterlyGoalPopoverContentInner({
 
         {/* overflow-y-auto allows Details content to scroll if it overflows */}
         <TabsContent value="details" className="mt-4 overflow-y-auto">
-          {goal.details && (
-            <GoalDetailsSection
-              title={goal.title}
-              details={goal.details}
-              onDetailsChange={handleDetailsChange}
-              showSeparator={false}
-            />
-          )}
+          <GoalDetailsSection
+            title={goal.title}
+            details={goal.details ?? ''}
+            onDetailsChange={handleDetailsChange}
+            showSeparator={false}
+            onEditClick={onEditClick}
+          />
 
           <GoalChildrenSection
             title="Weekly Goals"

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/StandardGoalPopoverContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/StandardGoalPopoverContent.tsx
@@ -26,6 +26,7 @@ import {
   GoalInitiativeField,
   GoalStatusIndicators,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -243,6 +244,7 @@ function StandardGoalPopoverContentInner({
   const { goal } = useGoalContext();
   const { year, quarter, weekNumber } = useWeek();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { handleNestedActiveChange } = useDialogEscapeHandler();
 
   return (
@@ -266,6 +268,7 @@ function StandardGoalPopoverContentInner({
             </div>
           }
           actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Quarterly} />}
+          onTitleClick={onTitleClick}
         />
 
         <GoalStatusIndicators isStarred={isStarred} isPinned={isPinned} />
@@ -291,14 +294,13 @@ function StandardGoalPopoverContentInner({
 
           {/* overflow-y-auto allows Details content to scroll if it overflows */}
           <TabsContent value="details" className="mt-4 overflow-y-auto">
-            {goal.details && (
-              <GoalDetailsSection
-                title={goal.title}
-                details={goal.details}
-                onDetailsChange={onDetailsChange}
-                showSeparator={false}
-              />
-            )}
+            <GoalDetailsSection
+              title={goal.title}
+              details={goal.details ?? ''}
+              onDetailsChange={onDetailsChange}
+              showSeparator={false}
+              onEditClick={onEditClick}
+            />
 
             <GoalChildrenSection
               title="Weekly Goals"

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPageContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPageContent.tsx
@@ -27,6 +27,7 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -234,6 +235,7 @@ function WeeklyGoalPageContentInner({
 }: WeeklyGoalPageContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
 
   return (
     <>
@@ -244,6 +246,7 @@ function WeeklyGoalPageContentInner({
           onToggleComplete={onToggleComplete}
           statusControls={<GoalStatusIcons goalId={goal._id} />}
           actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Weekly} />}
+          onTitleClick={onTitleClick}
         />
 
         <GoalCreatedDate createdAt={goal._creationTime} />
@@ -257,13 +260,12 @@ function WeeklyGoalPageContentInner({
           className="mt-3 space-y-2"
         />
 
-        {goal.details && (
-          <GoalDetailsSection
-            title={goal.title}
-            details={goal.details}
-            onDetailsChange={onDetailsChange}
-          />
-        )}
+        <GoalDetailsSection
+          title={goal.title}
+          details={goal.details ?? ''}
+          onDetailsChange={onDetailsChange}
+          onEditClick={onEditClick}
+        />
 
         <GoalChildrenSection
           title="Daily Goals"

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPopover.tsx
@@ -16,6 +16,7 @@ import {
   GoalHeader,
   useGoalDisplayContext,
   useGoalEditContext,
+  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -154,6 +155,7 @@ function WeeklyGoalPopoverContentInner({
 }: WeeklyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
+  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter, weekNumber } = useWeek();
@@ -172,6 +174,7 @@ function WeeklyGoalPopoverContentInner({
         onToggleComplete={onToggleComplete}
         statusControls={<GoalStatusIcons goalId={goal._id} />}
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Weekly} />}
+        onTitleClick={onTitleClick}
       />
 
       <GoalCreatedDate createdAt={goal._creationTime} />
@@ -189,14 +192,13 @@ function WeeklyGoalPopoverContentInner({
 
         {/* overflow-y-auto allows Details content to scroll if it overflows */}
         <TabsContent value="details" className="mt-4 overflow-y-auto">
-          {goal.details && (
-            <GoalDetailsSection
-              title={goal.title}
-              details={goal.details}
-              onDetailsChange={handleDetailsChange}
-              showSeparator={false}
-            />
-          )}
+          <GoalDetailsSection
+            title={goal.title}
+            details={goal.details ?? ''}
+            onDetailsChange={handleDetailsChange}
+            showSeparator={false}
+            onEditClick={onEditClick}
+          />
 
           <GoalChildrenSection
             title="Daily Goals"

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { FixedSizeDialog, FixedSizeDialogContent } from '@/components/ui/fixed-size-dialog';
 import { InteractiveHTML } from '@/components/ui/interactive-html';
 import { SafeHTML } from '@/components/ui/safe-html';
+import { isInteractiveClickTarget } from '@/lib/dom/isInteractiveClickTarget';
 import { cn } from '@/lib/utils';
 
 /**
@@ -26,6 +27,8 @@ export interface GoalDetailsContentProps {
   onDetailsChange?: (newDetails: string) => void;
   /** If true, task list checkboxes are disabled */
   readOnly?: boolean;
+  /** When set, clicking non-interactive details area starts editing */
+  onEditClick?: () => void;
 }
 
 /**
@@ -43,6 +46,7 @@ export interface GoalDetailsContentProps {
  * />
  * ```
  */
+// fallow-ignore-next-line complexity
 export function GoalDetailsContent({
   title,
   details,
@@ -51,9 +55,15 @@ export function GoalDetailsContent({
   showExpandAction = true,
   onDetailsChange,
   readOnly = false,
+  onEditClick,
 }: GoalDetailsContentProps) {
   const [isFullViewOpen, setIsFullViewOpen] = useState(false);
   const hasInteractiveFeatures = onDetailsChange && !readOnly;
+
+  const handleDetailsClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!onEditClick || isInteractiveClickTarget(e.target)) return;
+    onEditClick();
+  };
 
   return (
     <>
@@ -82,10 +92,24 @@ export function GoalDetailsContent({
         )}
 
         <div
+          onClick={onEditClick ? handleDetailsClick : undefined}
           className={cn(
             'min-w-0 overflow-x-hidden overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30',
+            onEditClick && 'cursor-pointer hover:bg-muted/50 transition-colors',
             className
           )}
+          role={onEditClick ? 'button' : undefined}
+          tabIndex={onEditClick ? 0 : undefined}
+          onKeyDown={
+            onEditClick
+              ? (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onEditClick();
+                  }
+                }
+              : undefined
+          }
         >
           {hasInteractiveFeatures ? (
             <InteractiveHTML

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoalDetailsSection } from './GoalDetailsSection';
+
+vi.mock('@/components/ui/rich-text-editor', () => ({
+  isHTMLEmpty: (html: string) => {
+    const textContent = html.replace(/<[^>]*>/g, '');
+    const cleanContent = textContent.replace(/[\s\u00A0\u200B\u200C\u200D\uFEFF]/g, '');
+    return cleanContent === '';
+  },
+}));
+
+vi.mock('@/components/ui/safe-html', () => ({
+  SafeHTML: ({ html, className }: { html: string; className?: string }) => (
+    <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  ),
+}));
+
+vi.mock('@/components/ui/interactive-html', () => ({
+  InteractiveHTML: ({ html, className }: { html: string; className?: string }) => (
+    <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  ),
+}));
+
+describe('GoalDetailsSection', () => {
+  it('shows empty state for undefined details when onEditClick is provided', () => {
+    const onEditClick = vi.fn();
+    render(
+      <GoalDetailsSection title="Goal" details="" onEditClick={onEditClick} showSeparator={false} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
+    expect(onEditClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows empty state for empty HTML details', () => {
+    render(
+      <GoalDetailsSection
+        title="Goal"
+        details="<p></p>"
+        onEditClick={vi.fn()}
+        showSeparator={false}
+      />
+    );
+    expect(screen.getByRole('button', { name: /no details/i })).toBeInTheDocument();
+  });
+
+  it('renders content when details have text', () => {
+    render(<GoalDetailsSection title="Goal" details="<p>Hello</p>" showSeparator={false} />);
+    expect(screen.queryByRole('button', { name: /no details/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('returns null when no details and no onEditClick', () => {
+    const { container } = render(
+      <GoalDetailsSection title="Goal" details="" showSeparator={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
@@ -1,5 +1,6 @@
 import { GoalDetailsContent } from './GoalDetailsContent';
 
+import { isHTMLEmpty } from '@/components/ui/rich-text-editor';
 import { Separator } from '@/components/ui/separator';
 
 export interface GoalDetailsSectionProps {
@@ -40,13 +41,15 @@ export function GoalDetailsSection({
   readOnly = false,
   onEditClick,
 }: GoalDetailsSectionProps) {
-  if (!details && !onEditClick) return null;
+  const hasDetails = !isHTMLEmpty(details);
+
+  if (!hasDetails && !onEditClick) return null;
 
   return (
     <>
       {showSeparator && <Separator className="my-2" />}
       <div className="pt-1">
-        {details ? (
+        {hasDetails ? (
           <GoalDetailsContent
             title={title}
             details={details}

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
@@ -13,6 +13,8 @@ export interface GoalDetailsSectionProps {
   onDetailsChange?: (newDetails: string) => void;
   /** If true, task list checkboxes are disabled */
   readOnly?: boolean;
+  /** When set, clicking details (or empty state) starts editing */
+  onEditClick?: () => void;
 }
 
 /**
@@ -29,27 +31,38 @@ export interface GoalDetailsSectionProps {
  * />
  * ```
  */
+// fallow-ignore-next-line complexity
 export function GoalDetailsSection({
   title,
   details,
   showSeparator = true,
   onDetailsChange,
   readOnly = false,
+  onEditClick,
 }: GoalDetailsSectionProps) {
-  if (!details) {
-    return null;
-  }
+  if (!details && !onEditClick) return null;
 
   return (
     <>
       {showSeparator && <Separator className="my-2" />}
       <div className="pt-1">
-        <GoalDetailsContent
-          title={title}
-          details={details}
-          onDetailsChange={onDetailsChange}
-          readOnly={readOnly}
-        />
+        {details ? (
+          <GoalDetailsContent
+            title={title}
+            details={details}
+            onDetailsChange={onDetailsChange}
+            readOnly={readOnly}
+            onEditClick={onEditClick}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={onEditClick}
+            className="w-full text-left text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md px-3 py-4 transition-colors cursor-pointer"
+          >
+            No details — click to add
+          </button>
+        )}
       </div>
     </>
   );

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditContext.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditContext.tsx
@@ -1,6 +1,8 @@
 import type { GoalWithDetailsAndChildren } from '@workspace/backend/src/usecase/getWeekDetails';
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
+import { useGoalContext } from '@/contexts/GoalContext';
+
 /**
  * Context value type for goal editing state management.
  */
@@ -82,4 +84,22 @@ export function GoalEditProvider({ children }: _GoalEditProviderProps) {
   );
 
   return <_GoalEditContext.Provider value={value}>{children}</_GoalEditContext.Provider>;
+}
+
+/**
+ * Hook to start editing the current goal from title or details click handlers.
+ * Must be used within GoalProvider and GoalEditProvider.
+ */
+export function useStartEditingGoal() {
+  const { goal } = useGoalContext();
+  const { startEditing } = useGoalEditContext();
+
+  const handleStartEditing = useCallback(() => {
+    startEditing(goal);
+  }, [startEditing, goal]);
+
+  return {
+    onTitleClick: handleStartEditing,
+    onEditClick: handleStartEditing,
+  };
 }

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoalHeader } from './GoalHeader';
+
+describe('GoalHeader', () => {
+  it('renders title as a button and calls onTitleClick when clicked', () => {
+    const onTitleClick = vi.fn();
+
+    render(
+      <GoalHeader
+        title="My Goal"
+        isComplete={false}
+        onToggleComplete={vi.fn()}
+        onTitleClick={onTitleClick}
+      />
+    );
+
+    const titleButton = screen.getByRole('button', { name: 'My Goal' });
+    fireEvent.click(titleButton);
+
+    expect(onTitleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders title as heading when onTitleClick is not provided', () => {
+    render(<GoalHeader title="Static Goal" isComplete={false} />);
+
+    expect(screen.getByRole('heading', { name: 'Static Goal' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Static Goal' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
@@ -17,6 +17,8 @@ export interface GoalHeaderProps {
   actionMenu?: ReactNode;
   /** Title size variant */
   size?: 'default' | 'large';
+  /** When set, title is clickable to start editing */
+  onTitleClick?: () => void;
 }
 
 /**
@@ -42,6 +44,7 @@ export function GoalHeader({
   statusControls,
   actionMenu,
   size = 'default',
+  onTitleClick,
 }: GoalHeaderProps) {
   const titleClassName = size === 'large' ? 'font-semibold text-xl' : 'font-semibold text-lg';
 
@@ -54,7 +57,17 @@ export function GoalHeader({
           disabled={disableCompletion || !onToggleComplete}
           onCheckedChange={(checked) => onToggleComplete?.(checked === true)}
         />
-        <h3 className={`${titleClassName} break-words flex-1 leading-tight`}>{title}</h3>
+        {onTitleClick ? (
+          <button
+            type="button"
+            onClick={onTitleClick}
+            className={`${titleClassName} break-words flex-1 leading-tight text-left hover:text-primary transition-colors cursor-pointer`}
+          >
+            {title}
+          </button>
+        ) : (
+          <h3 className={`${titleClassName} break-words flex-1 leading-tight`}>{title}</h3>
+        )}
       </div>
       <div className="flex items-center gap-1">
         {statusControls}

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/index.ts
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/index.ts
@@ -23,7 +23,7 @@ export {
 export { GoalDomainDisplay, type GoalDomainDisplayProps } from './GoalDomainDisplay';
 export { GoalDueDateDisplay, type GoalDueDateDisplayProps } from './GoalDueDateDisplay';
 export { GoalInitiativeField } from './GoalInitiativeField';
-export { GoalEditProvider, useGoalEditContext } from './GoalEditContext';
+export { GoalEditProvider, useGoalEditContext, useStartEditingGoal } from './GoalEditContext';
 export { GoalEditModal, type GoalEditModalProps } from './GoalEditModal';
 export { GoalHeader, type GoalHeaderProps } from './GoalHeader';
 export { GoalStatusIndicators, type GoalStatusIndicatorsProps } from './GoalStatusIndicators';

--- a/apps/webapp/src/lib/dom/isInteractiveClickTarget.test.ts
+++ b/apps/webapp/src/lib/dom/isInteractiveClickTarget.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { isInteractiveClickTarget } from './isInteractiveClickTarget';
+
+describe('isInteractiveClickTarget', () => {
+  it('returns true for anchor elements', () => {
+    const anchor = document.createElement('a');
+    anchor.href = 'https://example.com';
+    document.body.appendChild(anchor);
+
+    expect(isInteractiveClickTarget(anchor)).toBe(true);
+
+    document.body.removeChild(anchor);
+  });
+
+  it('returns true for input elements', () => {
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    document.body.appendChild(input);
+
+    expect(isInteractiveClickTarget(input)).toBe(true);
+
+    document.body.removeChild(input);
+  });
+
+  it('returns true for task list items', () => {
+    const taskItem = document.createElement('li');
+    taskItem.setAttribute('data-type', 'taskItem');
+    document.body.appendChild(taskItem);
+
+    expect(isInteractiveClickTarget(taskItem)).toBe(true);
+
+    document.body.removeChild(taskItem);
+  });
+
+  it('returns false for plain paragraph elements', () => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Some details text';
+    document.body.appendChild(paragraph);
+
+    expect(isInteractiveClickTarget(paragraph)).toBe(false);
+
+    document.body.removeChild(paragraph);
+  });
+
+  it('returns false for null target', () => {
+    expect(isInteractiveClickTarget(null)).toBe(false);
+  });
+});

--- a/apps/webapp/src/lib/dom/isInteractiveClickTarget.ts
+++ b/apps/webapp/src/lib/dom/isInteractiveClickTarget.ts
@@ -1,0 +1,7 @@
+const INTERACTIVE_SELECTOR =
+  'a, button, input, textarea, select, label, [contenteditable="true"], li[data-type="taskItem"]';
+
+export function isInteractiveClickTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(target.closest(INTERACTIVE_SELECTOR));
+}


### PR DESCRIPTION
## Summary
- Add click-to-edit for goal titles and details across all 9 goal detail surfaces (popovers, page content, quick view modals)
- Centralize edit invocation via `useStartEditingGoal()` hook and `isInteractiveClickTarget()` helper to preserve task-list checkbox and link behavior
- Show "No details — click to add" empty state when goals have no details
- Make initiative title and description clickable in `InitiativeDetailsDialog` to open the existing edit flow

## Test plan
- [ ] Click goal title in weekly/quarterly/daily/adhoc popovers → opens GoalEditModal
- [ ] Click goal details text (non-interactive area) → opens GoalEditModal
- [ ] Click task-list checkboxes in details → toggles completion without opening edit modal
- [ ] Click links in details → navigates normally
- [ ] Goal with no details shows "No details — click to add" → opens edit modal
- [ ] Click initiative title/description in InitiativeDetailsDialog → opens InitiativeFormDialog
- [ ] Existing ⋮ menu Edit still works
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes


Made with [Cursor](https://cursor.com)