### PR TITLE
feat(contacts): contact management and tagging (WIP)

### DIFF
--- a/apps/webapp/src/app/app/contacts/page.tsx
+++ b/apps/webapp/src/app/app/contacts/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import type { Doc } from '@workspace/backend/convex/_generated/dataModel';
+import { ContactRound, Loader2, Plus } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+import { ContactCard } from '@/components/molecules/contacts/ContactCard';
+import { ContactFormDialog } from '@/components/molecules/contacts/ContactFormDialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useContacts } from '@/hooks/useContacts';
+import { useSession } from '@/modules/auth/useSession';
+
+// fallow-ignore-next-line complexity
+export default function ContactsPage() {
+  const { sessionId } = useSession();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedContact, setSelectedContact] = useState<Doc<'contacts'> | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const {
+    contacts,
+    isLoading,
+    createContact,
+    updateContact,
+    deleteContact,
+    isCreating,
+    isUpdating,
+    isDeleting,
+  } = useContacts(sessionId, searchQuery);
+
+  const handleNewContact = useCallback(() => {
+    setSelectedContact(null);
+    setDialogOpen(true);
+  }, []);
+
+  const handleSelectContact = useCallback((contact: Doc<'contacts'>) => {
+    setSelectedContact(contact);
+    setDialogOpen(true);
+  }, []);
+
+  const handleCreate = useCallback(
+    async (input: Parameters<typeof createContact>[0]) => {
+      await createContact(input);
+      toast.success('Contact created');
+    },
+    [createContact]
+  );
+
+  const handleUpdate = useCallback(
+    async (...args: Parameters<typeof updateContact>) => {
+      await updateContact(...args);
+      toast.success('Contact updated');
+    },
+    [updateContact]
+  );
+
+  const handleDelete = useCallback(
+    async (contactId: Parameters<typeof deleteContact>[0]) => {
+      await deleteContact(contactId);
+      toast.success('Contact deleted');
+    },
+    [deleteContact]
+  );
+
+  const isFiltered = searchQuery.trim().length > 0;
+
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-6">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <ContactRound className="h-6 w-6 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold">Contacts</h1>
+        </div>
+        <Button onClick={handleNewContact}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Contact
+        </Button>
+      </div>
+
+      <p className="mb-6 text-muted-foreground">
+        Keep track of the people connected to your goals and progress.
+      </p>
+
+      <div className="mb-6">
+        <Input
+          type="search"
+          placeholder="Search contacts by name, email, or organization..."
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          className="max-w-md"
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : !contacts || contacts.length === 0 ? (
+        <div className="py-12 text-center">
+          <ContactRound className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+          <h2 className="mb-2 text-lg font-medium">
+            {isFiltered ? 'No contacts found' : 'No contacts yet'}
+          </h2>
+          <p className="mb-4 text-muted-foreground">
+            {isFiltered
+              ? 'Try a different search term.'
+              : 'Create your first contact to start tracking the people connected to your work.'}
+          </p>
+          {!isFiltered && (
+            <Button onClick={handleNewContact}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Contact
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4">
+          {contacts.map((contact) => (
+            <ContactCard key={contact._id} contact={contact} onSelect={handleSelectContact} />
+          ))}
+        </div>
+      )}
+
+      <ContactFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        contact={selectedContact}
+        onCreate={handleCreate}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+        isSubmitting={isCreating || isUpdating}
+        isDeleting={isDeleting}
+      />
+    </div>
+  );
+}

--- a/apps/webapp/src/components/UserMenu.tsx
+++ b/apps/webapp/src/components/UserMenu.tsx
@@ -2,7 +2,15 @@
 
 import { api } from '@workspace/backend/convex/_generated/api';
 import { useSessionMutation } from 'convex-helpers/react/sessions';
-import { BookOpen, LayoutDashboard, LogOut, Settings, User, UserCircle } from 'lucide-react';
+import {
+  BookOpen,
+  ContactRound,
+  LayoutDashboard,
+  LogOut,
+  Settings,
+  User,
+  UserCircle,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -157,6 +165,12 @@ function _renderUserDropdownMenu(
           <DropdownMenuItem className="cursor-pointer gap-2">
             <UserCircle className="h-4 w-4" />
             Profile
+          </DropdownMenuItem>
+        </Link>
+        <Link href="/app/contacts">
+          <DropdownMenuItem className="cursor-pointer gap-2">
+            <ContactRound className="h-4 w-4" />
+            Contacts
           </DropdownMenuItem>
         </Link>
         <Link href="/docs">

--- a/apps/webapp/src/components/molecules/contacts/ContactCard.tsx
+++ b/apps/webapp/src/components/molecules/contacts/ContactCard.tsx
@@ -1,0 +1,47 @@
+import type { Doc } from '@workspace/backend/convex/_generated/dataModel';
+import { ContactRound } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface ContactCardProps {
+  contact: Doc<'contacts'>;
+  onSelect: (contact: Doc<'contacts'>) => void;
+}
+
+export function ContactCard({ contact, onSelect }: ContactCardProps) {
+  const notesPreview = useMemo(() => {
+    if (!contact.notes) return null;
+    const trimmed = contact.notes.trim();
+    if (!trimmed) return null;
+    if (trimmed.length <= 120) return trimmed;
+    return `${trimmed.slice(0, 117)}...`;
+  }, [contact.notes]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(contact)}
+      aria-label={`View contact ${contact.name}`}
+      className={cn(
+        'w-full rounded-lg border bg-card p-4 text-left shadow-sm transition-colors',
+        'hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <ContactRound className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-medium">{contact.name}</p>
+          {(contact.organization || contact.email) && (
+            <p className="mt-1 truncate text-sm text-muted-foreground">
+              {[contact.organization, contact.email].filter(Boolean).join(' · ')}
+            </p>
+          )}
+          {notesPreview && (
+            <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">{notesPreview}</p>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -45,7 +44,6 @@ describe('ContactFormDialog', () => {
   });
 
   it('trims fields, omits blank optionals, and closes on successful create', async () => {
-    const user = userEvent.setup();
     const onCreate = vi.fn().mockResolvedValue(undefined);
     const onOpenChange = vi.fn();
 
@@ -59,10 +57,12 @@ describe('ContactFormDialog', () => {
       />
     );
 
-    await user.type(screen.getByLabelText(/^name$/i), '  Alice  ');
-    await user.type(screen.getByLabelText(/email/i), '  alice@example.com  ');
-    await user.type(screen.getByLabelText(/organization/i), '   ');
-    await user.click(screen.getByRole('button', { name: /create contact/i }));
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: '  Alice  ' } });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: '  alice@example.com  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/organization/i), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: /create contact/i }));
 
     await waitFor(() => {
       expect(onCreate).toHaveBeenCalledWith({
@@ -74,7 +74,6 @@ describe('ContactFormDialog', () => {
   });
 
   it('prepopulates edit mode and calls onUpdate with the selected contact ID', async () => {
-    const user = userEvent.setup();
     const onUpdate = vi.fn().mockResolvedValue(undefined);
     const contact = makeContact({ name: 'Alice' });
 
@@ -94,8 +93,8 @@ describe('ContactFormDialog', () => {
     expect(screen.getByLabelText(/organization/i)).toHaveValue('Acme Corp');
     expect(screen.getByLabelText(/notes/i)).toHaveValue('Met at a conference');
 
-    await user.clear(screen.getByLabelText(/email/i));
-    await user.click(screen.getByRole('button', { name: /save changes/i }));
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
     await waitFor(() => {
       expect(onUpdate).toHaveBeenCalledWith(CONTACT_ID, {
@@ -140,7 +139,6 @@ describe('ContactFormDialog', () => {
   });
 
   it('keeps the dialog open when save is rejected', async () => {
-    const user = userEvent.setup();
     const onCreate = vi.fn().mockRejectedValue(new Error('Save failed'));
     const onOpenChange = vi.fn();
 
@@ -154,8 +152,8 @@ describe('ContactFormDialog', () => {
       />
     );
 
-    await user.type(screen.getByLabelText(/^name$/i), 'Alice');
-    await user.click(screen.getByRole('button', { name: /create contact/i }));
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: 'Alice' } });
+    fireEvent.click(screen.getByRole('button', { name: /create contact/i }));
 
     await waitFor(() => {
       expect(toast).toHaveBeenCalled();

--- a/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ContactFormDialog } from './ContactFormDialog';
+
+import { toast } from '@/components/ui/use-toast';
+
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+const CONTACT_ID = 'contacts:test' as Id<'contacts'>;
+
+function makeContact(
+  overrides: Partial<Doc<'contacts'>> & Pick<Doc<'contacts'>, 'name'>
+): Doc<'contacts'> {
+  return {
+    _id: CONTACT_ID,
+    _creationTime: 0,
+    userId: 'users:test' as Doc<'contacts'>['userId'],
+    createdAt: 1,
+    updatedAt: 1,
+    email: 'alice@example.com',
+    organization: 'Acme Corp',
+    notes: 'Met at a conference',
+    ...overrides,
+  };
+}
+
+describe('ContactFormDialog', () => {
+  it('disables submit for whitespace-only name in create mode', () => {
+    render(
+      <ContactFormDialog
+        open
+        onOpenChange={vi.fn()}
+        onCreate={vi.fn().mockResolvedValue(undefined)}
+        onUpdate={vi.fn().mockResolvedValue(undefined)}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /create contact/i })).toBeDisabled();
+  });
+
+  it('trims fields, omits blank optionals, and closes on successful create', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(
+      <ContactFormDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreate={onCreate}
+        onUpdate={vi.fn().mockResolvedValue(undefined)}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/^name$/i), '  Alice  ');
+    await user.type(screen.getByLabelText(/email/i), '  alice@example.com  ');
+    await user.type(screen.getByLabelText(/organization/i), '   ');
+    await user.click(screen.getByRole('button', { name: /create contact/i }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        name: 'Alice',
+        email: 'alice@example.com',
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('prepopulates edit mode and calls onUpdate with the selected contact ID', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const contact = makeContact({ name: 'Alice' });
+
+    render(
+      <ContactFormDialog
+        open
+        contact={contact}
+        onOpenChange={vi.fn()}
+        onCreate={vi.fn().mockResolvedValue(undefined)}
+        onUpdate={onUpdate}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue('Alice');
+    expect(screen.getByLabelText(/email/i)).toHaveValue('alice@example.com');
+    expect(screen.getByLabelText(/organization/i)).toHaveValue('Acme Corp');
+    expect(screen.getByLabelText(/notes/i)).toHaveValue('Met at a conference');
+
+    await user.clear(screen.getByLabelText(/email/i));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(CONTACT_ID, {
+        name: 'Alice',
+        email: null,
+        organization: 'Acme Corp',
+        notes: 'Met at a conference',
+      });
+    });
+  });
+
+  it('requires delete confirmation before calling onDelete', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    const contact = makeContact({ name: 'Alice' });
+
+    render(
+      <ContactFormDialog
+        open
+        contact={contact}
+        onOpenChange={vi.fn()}
+        onCreate={vi.fn().mockResolvedValue(undefined)}
+        onUpdate={vi.fn().mockResolvedValue(undefined)}
+        onDelete={onDelete}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(onDelete).not.toHaveBeenCalled();
+
+    const alertDialog = await screen.findByRole('alertdialog');
+    expect(
+      within(alertDialog).getByRole('heading', { name: /delete contact/i })
+    ).toBeInTheDocument();
+
+    await user.click(within(alertDialog).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith(CONTACT_ID);
+    });
+  });
+
+  it('keeps the dialog open when save is rejected', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockRejectedValue(new Error('Save failed'));
+    const onOpenChange = vi.fn();
+
+    render(
+      <ContactFormDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreate={onCreate}
+        onUpdate={vi.fn().mockResolvedValue(undefined)}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/^name$/i), 'Alice');
+    await user.click(screen.getByRole('button', { name: /create contact/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByRole('heading', { name: /new contact/i })).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
 import { describe, expect, it, vi } from 'vitest';
@@ -108,7 +108,8 @@ describe('ContactFormDialog', () => {
   });
 
   it('requires delete confirmation before calling onDelete', async () => {
-    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    // Nested Dialog + AlertDialog focus traps overflow under userEvent in jsdom;
+    // use fireEvent for this interaction path.
     const onDelete = vi.fn().mockResolvedValue(undefined);
     const contact = makeContact({ name: 'Alice' });
 
@@ -123,7 +124,7 @@ describe('ContactFormDialog', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
     expect(onDelete).not.toHaveBeenCalled();
 
     const alertDialog = await screen.findByRole('alertdialog');
@@ -131,7 +132,7 @@ describe('ContactFormDialog', () => {
       within(alertDialog).getByRole('heading', { name: /delete contact/i })
     ).toBeInTheDocument();
 
-    await user.click(within(alertDialog).getByRole('button', { name: /^delete$/i }));
+    fireEvent.click(within(alertDialog).getByRole('button', { name: /^delete$/i }));
 
     await waitFor(() => {
       expect(onDelete).toHaveBeenCalledWith(CONTACT_ID);

--- a/apps/webapp/src/components/molecules/contacts/ContactFormDialog.tsx
+++ b/apps/webapp/src/components/molecules/contacts/ContactFormDialog.tsx
@@ -1,0 +1,306 @@
+'use client';
+// fallow-ignore-file code-duplication
+
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+import { ConvexError } from 'convex/values';
+import { ContactRound, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/use-toast';
+import { useFormSubmitShortcut } from '@/hooks/useFormSubmitShortcut';
+import {
+  contactToFormValues,
+  EMPTY_CONTACT_FORM,
+  normalizeContactForm,
+  normalizeContactFormForUpdate,
+  type ContactInput,
+  type UpdateContactInput,
+} from '@/lib/contact/contact-form';
+
+// fallow-ignore-next-line complexity
+function getContactErrorDetails(error: unknown): { code?: string; message?: string } {
+  if (error instanceof ConvexError) {
+    const data = error.data;
+    if (typeof data === 'object' && data !== null) {
+      return {
+        code: 'code' in data ? String(data.code) : undefined,
+        message: 'message' in data && typeof data.message === 'string' ? data.message : undefined,
+      };
+    }
+  }
+  if (error instanceof Error) return { message: error.message };
+  return {};
+}
+
+export interface ContactFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  contact?: Doc<'contacts'> | null;
+  onCreate: (input: ContactInput) => Promise<void>;
+  onUpdate: (contactId: Id<'contacts'>, input: UpdateContactInput) => Promise<void>;
+  onDelete: (contactId: Id<'contacts'>) => Promise<void>;
+  isSubmitting?: boolean;
+  isDeleting?: boolean;
+}
+
+// fallow-ignore-next-line complexity
+export function ContactFormDialog({
+  open,
+  onOpenChange,
+  contact,
+  onCreate,
+  onUpdate,
+  onDelete,
+  isSubmitting = false,
+  isDeleting = false,
+}: ContactFormDialogProps) {
+  const isEditMode = Boolean(contact);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [organization, setOrganization] = useState('');
+  const [notes, setNotes] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setName(EMPTY_CONTACT_FORM.name);
+      setEmail(EMPTY_CONTACT_FORM.email);
+      setOrganization(EMPTY_CONTACT_FORM.organization);
+      setNotes(EMPTY_CONTACT_FORM.notes);
+      setShowDeleteConfirm(false);
+      return;
+    }
+
+    if (contact) {
+      const values = contactToFormValues(contact);
+      setName(values.name);
+      setEmail(values.email);
+      setOrganization(values.organization);
+      setNotes(values.notes);
+    } else {
+      setName(EMPTY_CONTACT_FORM.name);
+      setEmail(EMPTY_CONTACT_FORM.email);
+      setOrganization(EMPTY_CONTACT_FORM.organization);
+      setNotes(EMPTY_CONTACT_FORM.notes);
+    }
+  }, [open, contact]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setShowDeleteConfirm(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const isBusy = isSubmitting || isDeleting;
+  const isSubmitDisabled = !name.trim() || isBusy;
+
+  // fallow-ignore-next-line complexity
+  const handleSubmit = useCallback(async () => {
+    if (isBusy) return;
+
+    const values = { name, email, organization, notes };
+
+    try {
+      if (isEditMode && contact) {
+        const normalized = normalizeContactFormForUpdate(values);
+        if (!normalized) return;
+        await onUpdate(contact._id, normalized);
+      } else {
+        const normalized = normalizeContactForm(values);
+        if (!normalized) return;
+        await onCreate(normalized);
+      }
+      setShowDeleteConfirm(false);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Failed to save contact:', error);
+      toast({
+        variant: 'destructive',
+        title: 'Could not save contact',
+        description: getContactErrorDetails(error).message ?? 'Please try again.',
+      });
+    }
+  }, [
+    contact,
+    email,
+    isBusy,
+    isEditMode,
+    name,
+    notes,
+    onCreate,
+    onOpenChange,
+    onUpdate,
+    organization,
+  ]);
+
+  const handleFormShortcut = useFormSubmitShortcut({
+    onSubmit: () => void handleSubmit(),
+    disabled: isSubmitDisabled,
+  });
+
+  const handleFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    void handleSubmit();
+  };
+
+  // fallow-ignore-next-line complexity
+  const handleDeleteConfirm = async () => {
+    if (!contact) return;
+
+    try {
+      await onDelete(contact._id);
+      setShowDeleteConfirm(false);
+      handleOpenChange(false);
+    } catch (error) {
+      console.error('Failed to delete contact:', error);
+      const { code, message } = getContactErrorDetails(error);
+
+      toast({
+        variant: 'destructive',
+        title: code === 'RESOURCE_IN_USE' ? 'Contact in use' : 'Could not delete contact',
+        description: message ?? 'Please try again.',
+      });
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <ContactRound className="h-5 w-5 text-primary" />
+              {isEditMode ? 'Edit Contact' : 'New Contact'}
+            </DialogTitle>
+            <DialogDescription>
+              {isEditMode
+                ? 'Update this contact’s details.'
+                : 'Add someone connected to your goals and progress.'}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleFormSubmit} onKeyDown={handleFormShortcut}>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="contact-name">Name</Label>
+                <Input
+                  id="contact-name"
+                  placeholder="Who is this contact?"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="contact-email">Email (optional)</Label>
+                <Input
+                  id="contact-email"
+                  type="email"
+                  placeholder="name@example.com"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="contact-organization">Organization (optional)</Label>
+                <Input
+                  id="contact-organization"
+                  placeholder="Company or team"
+                  value={organization}
+                  onChange={(event) => setOrganization(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="contact-notes">Notes (optional)</Label>
+                <Textarea
+                  id="contact-notes"
+                  placeholder="How you know them or context to remember..."
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  onKeyDown={handleFormShortcut}
+                  rows={3}
+                />
+              </div>
+            </div>
+            <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+              {isEditMode ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  disabled={isBusy}
+                >
+                  <Trash2 className="mr-1.5 h-4 w-4" />
+                  Delete
+                </Button>
+              ) : (
+                <span />
+              )}
+              <div className="flex gap-2 sm:ml-auto">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={isBusy}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSubmitDisabled}>
+                  {isSubmitting ? 'Saving...' : isEditMode ? 'Save Changes' : 'Create Contact'}
+                </Button>
+              </div>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete contact?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete &ldquo;{contact?.name}&rdquo;. Remove this contact from
+              linked goals and logs before deleting.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDeleteConfirm();
+              }}
+              variant="destructive"
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/webapp/src/components/molecules/focus/InitiativeActionMenu.test.tsx
+++ b/apps/webapp/src/components/molecules/focus/InitiativeActionMenu.test.tsx
@@ -42,7 +42,7 @@ describe('InitiativeActionMenu mark complete', () => {
     expect(onEndDateChange).not.toHaveBeenCalled();
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /complete initiative/i })).toBeInTheDocument();
-  });
+  }, 15_000);
 
   it('calls onEndDateChange with selected date when user confirms', async () => {
     const user = userEvent.setup();
@@ -71,7 +71,7 @@ describe('InitiativeActionMenu mark complete', () => {
     });
     const calledWith = onEndDateChange.mock.calls[0][0] as number;
     expect(calledWith).toBeGreaterThanOrEqual(startDate);
-  });
+  }, 15_000);
 
   it('does not show Mark as complete when initiative already has an end date', async () => {
     const user = userEvent.setup();
@@ -88,5 +88,5 @@ describe('InitiativeActionMenu mark complete', () => {
     await user.click(screen.getByRole('button'));
     expect(screen.queryByRole('menuitem', { name: /mark as complete/i })).not.toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /change end date/i })).toBeInTheDocument();
-  });
+  }, 15_000);
 });

--- a/apps/webapp/src/hooks/useContacts.tsx
+++ b/apps/webapp/src/hooks/useContacts.tsx
@@ -1,0 +1,64 @@
+import { api } from '@workspace/backend/convex/_generated/api';
+import type { Id } from '@workspace/backend/convex/_generated/dataModel';
+import { useMutation, useQuery } from 'convex/react';
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { useState } from 'react';
+
+import type { ContactInput, UpdateContactInput } from '@/lib/contact/contact-form';
+
+export function useContacts(sessionId: SessionId, search = '') {
+  const [isCreating, setIsCreating] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const trimmedSearch = search.trim();
+  const contacts = useQuery(api.contact.getContacts, {
+    sessionId,
+    ...(trimmedSearch ? { search: trimmedSearch } : {}),
+  });
+
+  const createContactMutation = useMutation(api.contact.createContact);
+  const updateContactMutation = useMutation(api.contact.updateContact);
+  const deleteContactMutation = useMutation(api.contact.deleteContact);
+
+  const createContact = async (input: ContactInput): Promise<Id<'contacts'>> => {
+    setIsCreating(true);
+    try {
+      return await createContactMutation({ sessionId, ...input });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const updateContact = async (
+    contactId: Id<'contacts'>,
+    input: UpdateContactInput
+  ): Promise<void> => {
+    setIsUpdating(true);
+    try {
+      await updateContactMutation({ sessionId, contactId, ...input });
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const deleteContact = async (contactId: Id<'contacts'>): Promise<void> => {
+    setIsDeleting(true);
+    try {
+      await deleteContactMutation({ sessionId, contactId });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return {
+    contacts,
+    isLoading: contacts === undefined,
+    createContact,
+    updateContact,
+    deleteContact,
+    isCreating,
+    isUpdating,
+    isDeleting,
+  };
+}

--- a/apps/webapp/src/lib/contact/contact-form.test.ts
+++ b/apps/webapp/src/lib/contact/contact-form.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { contactToFormValues, EMPTY_CONTACT_FORM, normalizeContactForm } from './contact-form';
+
+describe('normalizeContactForm', () => {
+  it('returns null for blank or whitespace-only name', () => {
+    expect(normalizeContactForm({ ...EMPTY_CONTACT_FORM, name: '' })).toBeNull();
+    expect(normalizeContactForm({ ...EMPTY_CONTACT_FORM, name: '   ' })).toBeNull();
+  });
+
+  it('trims all values', () => {
+    expect(
+      normalizeContactForm({
+        name: '  Alice  ',
+        email: '  alice@example.com  ',
+        organization: '  Acme  ',
+        notes: '  Met at conference  ',
+      })
+    ).toEqual({
+      name: 'Alice',
+      email: 'alice@example.com',
+      organization: 'Acme',
+      notes: 'Met at conference',
+    });
+  });
+
+  it('omits blank optional fields', () => {
+    expect(
+      normalizeContactForm({
+        name: 'Bob',
+        email: '  ',
+        organization: '',
+        notes: '   ',
+      })
+    ).toEqual({ name: 'Bob' });
+  });
+});
+
+describe('contactToFormValues', () => {
+  it('maps undefined optionals to empty strings', () => {
+    expect(
+      contactToFormValues({
+        name: 'Carol',
+      })
+    ).toEqual({
+      name: 'Carol',
+      email: '',
+      organization: '',
+      notes: '',
+    });
+  });
+});

--- a/apps/webapp/src/lib/contact/contact-form.ts
+++ b/apps/webapp/src/lib/contact/contact-form.ts
@@ -1,0 +1,73 @@
+export type ContactFormValues = {
+  name: string;
+  email: string;
+  organization: string;
+  notes: string;
+};
+
+export type ContactInput = {
+  name: string;
+  email?: string;
+  organization?: string;
+  notes?: string;
+};
+
+export type UpdateContactInput = {
+  name: string;
+  email?: string | null;
+  organization?: string | null;
+  notes?: string | null;
+};
+
+export const EMPTY_CONTACT_FORM: ContactFormValues = {
+  name: '',
+  email: '',
+  organization: '',
+  notes: '',
+};
+
+export function contactToFormValues(contact: {
+  name: string;
+  email?: string;
+  organization?: string;
+  notes?: string;
+}): ContactFormValues {
+  return {
+    name: contact.name,
+    email: contact.email ?? '',
+    organization: contact.organization ?? '',
+    notes: contact.notes ?? '',
+  };
+}
+
+// fallow-ignore-next-line complexity
+export function normalizeContactForm(values: ContactFormValues): ContactInput | null {
+  const trimmedName = values.name.trim();
+  if (!trimmedName) return null;
+
+  const result: ContactInput = { name: trimmedName };
+  const email = values.email.trim();
+  const organization = values.organization.trim();
+  const notes = values.notes.trim();
+
+  if (email) result.email = email;
+  if (organization) result.organization = organization;
+  if (notes) result.notes = notes;
+
+  return result;
+}
+
+// fallow-ignore-next-line complexity
+export function normalizeContactFormForUpdate(
+  values: ContactFormValues
+): UpdateContactInput | null {
+  const normalized = normalizeContactForm(values);
+  if (!normalized) return null;
+
+  return {
+    name: normalized.name,
+    email: values.email.trim() ? values.email.trim() : null,
+    organization: values.organization.trim() ? values.organization.trim() : null,
+    notes: values.notes.trim() ? values.notes.trim() : null,
+  };
+}

--- a/docs/plans/005-contact-management-and-tagging/overview.md
+++ b/docs/plans/005-contact-management-and-tagging/overview.md
@@ -1,0 +1,30 @@
+# Feature: Contact Management and Tagging
+
+## Summary
+
+Enable users to maintain a private list of contacts and associate them with goals, goal logs, quarterly reviews, and markdown content. Contacts are normalized per-user entities linked to goals and logs through join tables, with centralized search and lookup reused across management, tagging, review generation, and editor mention flows.
+
+## Goals
+
+1. Let users create, search, edit, and delete contacts in a dedicated management area
+2. Tag goals and goal logs to one or more contacts
+3. Surface associated contacts when generating quarterly reviews
+4. Support contact-name tagging in markdown with searchable autocomplete
+5. Keep contact lookup and association logic centralized in `api.contact`
+
+## Non-Goals
+
+1. Shared or team-visible contacts
+2. Contact avatars, phone numbers, aliases, or pagination
+3. Separate contact detail routes (management is a compact list + dialog surface)
+4. Soft deletion or contact merge/dedupe tooling
+5. Real-time collaborative contact editing
+
+## User Story
+
+As a user, I should be able to maintain a list of contacts. I should be able to tag goals to individuals and look them up when generating reviews and work with them. This should work with the logs too. I should be able to tag their names in the markdown and search for matching contacts. There should also be a place I can use to manage contacts.
+
+## Branch and PR Status
+
+- **Branch:** `feature/contact-management-and-tagging`
+- **PR:** Draft — work paused; resume by completing remaining phases in `phases.md`

--- a/docs/plans/005-contact-management-and-tagging/phases.md
+++ b/docs/plans/005-contact-management-and-tagging/phases.md
@@ -96,7 +96,7 @@ Users can search, create, inspect, edit, and delete contacts from `/app/contacts
 - [x] `/app/contacts` page and components implemented
 - [x] UserMenu navigation wired
 - [ ] Full webapp test suite and typecheck verified at PR completion time
-- [ ] Committed on feature branch (pending this draft PR)
+- [x] Committed as `272445e6` — `feat(contacts): add contact management UI and implementation plan`
 
 ### Files
 

--- a/docs/plans/005-contact-management-and-tagging/phases.md
+++ b/docs/plans/005-contact-management-and-tagging/phases.md
@@ -1,0 +1,272 @@
+# Implementation Phases: Contact Management and Tagging
+
+## Phase Overview
+
+| Phase   | Description                             | Scope           | Status          |
+| ------- | --------------------------------------- | --------------- | --------------- |
+| Phase 1 | Convex contacts domain and associations | Backend         | **Complete**    |
+| Phase 2 | Contact management UI                   | Frontend        | **In progress** |
+| Phase 3 | Goal contact tagging                    | Full stack (UI) | Pending         |
+| Phase 4 | Goal log contact tagging                | Full stack (UI) | Pending         |
+| Phase 5 | Quarterly review contact lookup         | Frontend        | Pending         |
+| Phase 6 | Markdown contact mentions               | Frontend        | Pending         |
+| Phase 7 | Integration verification and polish     | Full stack      | Pending         |
+
+Implementation order is dependency-driven: backend contracts first, then management UI, then goal/log/review/markdown integrations, then final verification.
+
+---
+
+## Phase 1: Convex Contacts Domain and Associations
+
+### Objective
+
+Establish ownership-safe contacts CRUD/search and normalized many-to-many links between contacts, goals, and goal logs.
+
+### Deliverables
+
+1. **Schema tables** in `services/backend/convex/schema.ts`
+   - `contacts` — per-user contact records (name required; email, organization, notes optional)
+   - `goalContacts` — join table linking goals to contacts
+   - `goalLogContacts` — join table linking goal logs to contacts
+   - Composite indexes for user-scoped lookups; no embedded `contactIds` arrays on goals or goalLogs
+
+2. **API module** `services/backend/convex/contact.ts`
+   - `createContact`, `updateContact`, `deleteContact`
+   - `getContacts` (search + alphabetical sort), `getContact`
+   - `setGoalContacts`, `getGoalContacts`
+   - `setGoalLogContacts`, `getGoalLogContacts`
+   - `getContactWork` — returns linked goals and logs for review workflows
+
+3. **TDD test suite** `services/backend/convex/contact.spec.ts` (11 cases)
+   - CRUD trimming/validation, case-insensitive search, cross-user isolation
+   - Idempotent deduplicated association replacement
+   - `RESOURCE_IN_USE` deletion guard when linked to goals or logs
+
+### Success Criteria
+
+- [x] All 11 contact backend tests pass
+- [x] Backend typecheck passes
+- [x] Committed as `f73e74ad` — `feat(contacts): add Convex contacts domain and goal/log association APIs`
+
+### Files
+
+- `services/backend/convex/schema.ts` (modified)
+- `services/backend/convex/contact.ts` (new)
+- `services/backend/convex/contact.spec.ts` (new)
+- `services/backend/convex/_generated/api.d.ts` (regenerated)
+
+---
+
+## Phase 2: Contact Management UI
+
+### Objective
+
+Users can search, create, inspect, edit, and delete contacts from `/app/contacts`, reachable from the authenticated user menu.
+
+### Deliverables
+
+1. **Form helpers** `apps/webapp/src/lib/contact/contact-form.ts` + tests
+   - `ContactFormValues`, `ContactInput`, `normalizeContactForm`, `contactToFormValues`
+
+2. **Data hook** `apps/webapp/src/hooks/useContacts.tsx`
+   - Wraps `api.contact` query and CRUD mutations
+   - Preserves distinct loading state (does not coerce `undefined` to `[]`)
+
+3. **UI components**
+   - `ContactCard.tsx` — accessible button-styled row
+   - `ContactFormDialog.tsx` — create/edit with nested delete confirmation + tests
+
+4. **Management page** `apps/webapp/src/app/app/contacts/page.tsx`
+   - Search, loading, empty (first-use and filtered), create/edit/delete flows
+   - Toast feedback on successful mutations
+
+5. **Navigation** `apps/webapp/src/components/UserMenu.tsx`
+   - Contacts link between Profile and Documentation
+
+### UX Contracts
+
+- Name required; email, organization, notes optional
+- Search uses backend `getContacts({ search })` semantics
+- Deleting a linked contact shows actionable `RESOURCE_IN_USE` error without silently closing dialogs
+- Keyboard-friendly: Cmd/Ctrl+Enter submit via `useFormSubmitShortcut`
+
+### Success Criteria
+
+- [x] TDD helper and dialog tests authored
+- [x] `/app/contacts` page and components implemented
+- [x] UserMenu navigation wired
+- [ ] Full webapp test suite and typecheck verified at PR completion time
+- [ ] Committed on feature branch (pending this draft PR)
+
+### Files
+
+- `apps/webapp/src/lib/contact/contact-form.ts` (new)
+- `apps/webapp/src/lib/contact/contact-form.test.ts` (new)
+- `apps/webapp/src/hooks/useContacts.tsx` (new)
+- `apps/webapp/src/components/molecules/contacts/ContactCard.tsx` (new)
+- `apps/webapp/src/components/molecules/contacts/ContactFormDialog.tsx` (new)
+- `apps/webapp/src/components/molecules/contacts/ContactFormDialog.test.tsx` (new)
+- `apps/webapp/src/app/app/contacts/page.tsx` (new)
+- `apps/webapp/src/components/UserMenu.tsx` (modified)
+
+---
+
+## Phase 3: Goal Contact Tagging
+
+### Objective
+
+Users can tag one or more contacts on a goal from goal details / edit surfaces.
+
+### Deliverables
+
+1. **Reusable selector component** (mirror `GoalInitiativeField` / `InitiativeSelector` patterns)
+   - Multi-select contact picker with search
+   - Shows currently linked contacts as removable chips/badges
+
+2. **Integration points**
+   - Goal details modal / edit flows (adhoc, weekly, quarterly as applicable)
+   - Calls `setGoalContacts` on save; reads via `getGoalContacts`
+
+3. **Component tests** for selector behavior (search, select, deselect, empty state)
+
+### Success Criteria
+
+- [ ] User can add/remove contacts on a goal from goal details
+- [ ] Associations persist and reload correctly
+- [ ] Cross-user contacts cannot be selected
+- [ ] Tests cover selector interactions
+
+### Files (planned)
+
+- `apps/webapp/src/components/molecules/contacts/ContactSelector.tsx` (new)
+- `apps/webapp/src/components/molecules/contacts/GoalContactField.tsx` (new)
+- Goal details popover / modal integration files (modified)
+
+---
+
+## Phase 4: Goal Log Contact Tagging
+
+### Objective
+
+Users can tag contacts on individual goal logs, using the same selector patterns as goals.
+
+### Deliverables
+
+1. **Log contact field** integrated into goal log create/edit forms
+   - Calls `setGoalLogContacts` / `getGoalLogContacts`
+
+2. **Consistent UX** with Phase 3 selector (shared `ContactSelector` component)
+
+3. **Tests** for log form integration
+
+### Success Criteria
+
+- [ ] User can tag contacts when creating or editing a goal log
+- [ ] Log contact associations persist and display on reload
+- [ ] Deletion guards on contacts still work when logs are linked
+
+### Files (planned)
+
+- Goal log form components (modified)
+- Reuse `ContactSelector` from Phase 3
+
+---
+
+## Phase 5: Quarterly Review Contact Lookup
+
+### Objective
+
+When generating or viewing quarterly reviews, surface contacts linked to relevant goals and logs so the user can work with the people involved.
+
+### Deliverables
+
+1. **Review data integration**
+   - Use `getContactWork` and/or batch `getGoalContacts` / `getGoalLogContacts` for goals/logs in review scope
+   - Present associated contacts in quarterly summary / pull-preview flows
+
+2. **Filtering**
+   - Allow narrowing review content by contact where appropriate
+
+3. **Tests** for contact aggregation in review contexts
+
+### Success Criteria
+
+- [ ] Quarterly review flows show contacts linked to in-scope goals/logs
+- [ ] Contact lookup is centralized through `api.contact` (no duplicated relation queries)
+- [ ] Empty/no-contact cases handled gracefully
+
+### Files (planned)
+
+- `apps/webapp/src/app/app/goal/quarterly-summary/page.tsx` (modified)
+- Quarterly pull-preview components (modified)
+- Supporting hooks/utilities as needed
+
+---
+
+## Phase 6: Markdown Contact Mentions
+
+### Objective
+
+Users can tag contact names in markdown/rich-text content with autocomplete search matching existing contacts.
+
+### Deliverables
+
+1. **Mention trigger** in rich text editor (e.g. `@` or existing mention pattern)
+2. **Autocomplete popover** querying `getContacts({ search })` with debounced input
+3. **Rendered mention** — stored representation that resolves to contact identity
+4. **Tests** for mention insertion and search matching
+
+### Success Criteria
+
+- [ ] Typing a contact trigger shows searchable contact suggestions
+- [ ] Selecting a contact inserts a mention tied to the contact record
+- [ ] Search is case-insensitive and matches name/email/organization (same as management search)
+
+### Files (planned)
+
+- Rich text editor mention extension (modified or new)
+- `apps/webapp/src/components/molecules/contacts/ContactMentionList.tsx` (new, planned)
+
+---
+
+## Phase 7: Integration Verification and Polish
+
+### Objective
+
+End-to-end verification, stale-link cleanup if needed, and PR readiness.
+
+### Deliverables
+
+1. **Full test pass** — backend + webapp typecheck and test suites
+2. **Stale-link cleanup** — ensure goal/log deletion removes orphaned join rows (if not already handled)
+3. **Accessibility and responsive pass** on all new surfaces
+4. **Mark PR ready for review** (when feature is complete)
+
+### Success Criteria
+
+- [ ] All project tests pass
+- [ ] No orphaned `goalContacts` / `goalLogContacts` rows after entity deletion
+- [ ] Draft PR converted to ready-for-review when all phases complete
+
+---
+
+## Shared Architecture Decisions
+
+| Decision           | Choice                                   | Rationale                                               |
+| ------------------ | ---------------------------------------- | ------------------------------------------------------- |
+| Relationship model | Normalized join tables                   | Many-to-many; avoids array drift on goals/logs          |
+| Ownership          | Per-user private contacts                | Matches existing user-scoped data patterns              |
+| Search             | Backend `getContacts` everywhere         | Single matching semantics across UI and mentions        |
+| Management UX      | List + dialog (no detail route)          | Compact surface; matches initiatives/documents patterns |
+| Deletion           | Hard delete with `RESOURCE_IN_USE` guard | Prevents orphan relations; forces explicit untagging    |
+| Testing            | TDD per slice                            | Backend 11 tests done; frontend tests per phase         |
+
+## Resume Checklist
+
+When returning to this feature:
+
+1. Verify Phase 2 tests and typecheck; commit if not already done
+2. Implement Phase 3 (goal tagging) — highest user-visible value after management UI
+3. Phase 4 (log tagging) — reuses Phase 3 selector
+4. Phases 5–6 in parallel only after 3–4 stabilize
+5. Phase 7 before marking PR ready

--- a/docs/plans/005-contact-management-and-tagging/prd.md
+++ b/docs/plans/005-contact-management-and-tagging/prd.md
@@ -1,0 +1,53 @@
+# PRD: Contact Management and Tagging
+
+## Problem
+
+Users track goals and progress involving specific people, but the app has no first-class way to record who is involved, link people to goals/logs, or find related work when preparing reviews or writing notes.
+
+## Solution
+
+Add a contacts feature with:
+
+- A private per-user contact list (name + optional email, organization, notes)
+- Many-to-many tagging on goals and goal logs
+- Contact lookup in quarterly review workflows
+- Searchable contact mentions in markdown content
+- A dedicated `/app/contacts` management page
+
+## Requirements
+
+### Must Have
+
+- CRUD + search for contacts (backend + management UI)
+- Tag goals to contacts; tag goal logs to contacts
+- Look up contacts when generating reviews
+- Tag contact names in markdown with matching search
+- Dedicated contact management area
+- TDD for backend and frontend slices
+- User-scoped data with ownership validation
+
+### Should Have
+
+- Consistent UX with initiatives/documents patterns
+- Actionable errors when deleting in-use contacts
+- Keyboard shortcuts in forms (Cmd/Ctrl+Enter)
+
+### Won't Have (this iteration)
+
+- Team/shared contacts
+- Phone numbers, avatars, aliases
+- Pagination
+- Contact merge/dedupe
+
+## Acceptance Criteria (full feature)
+
+1. User can create, edit, delete, and search contacts at `/app/contacts`
+2. User can tag one or more contacts on a goal from goal details
+3. User can tag contacts on goal logs
+4. Quarterly review flows surface contacts linked to in-scope work
+5. Markdown editor supports contact mention autocomplete
+6. All new tests pass; typecheck clean
+
+## Implementation Plan
+
+See [phases.md](./phases.md) for slice-by-slice breakdown and current status.

--- a/services/backend/convex/_generated/api.d.ts
+++ b/services/backend/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as auth_google from "../auth/google.js";
 import type * as bff_focus from "../bff/focus.js";
 import type * as checklists from "../checklists.js";
 import type * as cleanupTasks from "../cleanupTasks.js";
+import type * as contact from "../contact.js";
 import type * as crypto from "../crypto.js";
 import type * as dashboard from "../dashboard.js";
 import type * as discussions from "../discussions.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   "bff/focus": typeof bff_focus;
   checklists: typeof checklists;
   cleanupTasks: typeof cleanupTasks;
+  contact: typeof contact;
   crypto: typeof crypto;
   dashboard: typeof dashboard;
   discussions: typeof discussions;

--- a/services/backend/convex/contact.spec.ts
+++ b/services/backend/convex/contact.spec.ts
@@ -1,0 +1,527 @@
+import { ConvexError } from 'convex/values';
+import type { SessionId } from 'convex-helpers/server/sessions';
+import { describe, expect, test } from 'vitest';
+
+import { api } from './_generated/api';
+import schema from './schema';
+import { convexTest } from '../src/util/test';
+
+const createTestSession = async (ctx: ReturnType<typeof convexTest>): Promise<SessionId> => {
+  const sessionId = crypto.randomUUID() as SessionId;
+  await ctx.mutation(api.auth.loginAnon, { sessionId });
+  return sessionId;
+};
+
+const expectConvexError = async (promise: Promise<unknown>, code: string): Promise<void> => {
+  try {
+    await promise;
+    expect.fail('Expected ConvexError');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConvexError);
+    expect((error as ConvexError<{ code: string }>).data.code).toBe(code);
+  }
+};
+
+describe('contact', () => {
+  test('createContact trims fields and stores timestamps', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const before = Date.now();
+
+    const contactId = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: '  Alice Smith  ',
+      email: '  alice@example.com  ',
+      organization: '  Acme Corp  ',
+      notes: '  Met at conference  ',
+    });
+
+    const after = Date.now();
+    const contact = await ctx.run(async (dbCtx) => dbCtx.db.get('contacts', contactId));
+
+    expect(contact?.name).toBe('Alice Smith');
+    expect(contact?.email).toBe('alice@example.com');
+    expect(contact?.organization).toBe('Acme Corp');
+    expect(contact?.notes).toBe('Met at conference');
+    expect(contact?.createdAt).toBeGreaterThanOrEqual(before);
+    expect(contact?.createdAt).toBeLessThanOrEqual(after);
+    expect(contact?.updatedAt).toBe(contact?.createdAt);
+  });
+
+  test('createContact rejects blank name', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    await expectConvexError(
+      ctx.mutation(api.contact.createContact, {
+        sessionId,
+        name: '   ',
+      }),
+      'INVALID_ARGUMENT'
+    );
+  });
+
+  test('updateContact updates name and clears optional fields with null/blank', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const contactId = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Bob',
+      email: 'bob@example.com',
+      organization: 'Beta Inc',
+      notes: 'Old notes',
+    });
+
+    await ctx.mutation(api.contact.updateContact, {
+      sessionId,
+      contactId,
+      name: '  Robert  ',
+      email: null,
+      organization: '  ',
+      notes: null,
+    });
+
+    const contact = await ctx.run(async (dbCtx) => dbCtx.db.get('contacts', contactId));
+    expect(contact?.name).toBe('Robert');
+    expect(contact?.email).toBeUndefined();
+    expect(contact?.organization).toBeUndefined();
+    expect(contact?.notes).toBeUndefined();
+    if (!contact) throw new Error('Expected contact to exist');
+    expect(contact.updatedAt).toBeGreaterThanOrEqual(contact.createdAt);
+  });
+
+  test('getContacts sorts by name and searches name/email/organization case-insensitively', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Zara',
+      email: 'zara@example.com',
+    });
+    await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Alice',
+      organization: 'Zenith Labs',
+    });
+    await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Mike',
+      email: 'MIKE@COMPANY.ORG',
+    });
+
+    const allContacts = await ctx.query(api.contact.getContacts, { sessionId });
+    expect(allContacts.map((c) => c.name)).toEqual(['Alice', 'Mike', 'Zara']);
+
+    const byName = await ctx.query(api.contact.getContacts, { sessionId, search: 'ali' });
+    expect(byName.map((c) => c.name)).toEqual(['Alice']);
+
+    const byEmail = await ctx.query(api.contact.getContacts, { sessionId, search: 'company.org' });
+    expect(byEmail.map((c) => c.name)).toEqual(['Mike']);
+
+    const byOrg = await ctx.query(api.contact.getContacts, { sessionId, search: 'zenith' });
+    expect(byOrg.map((c) => c.name)).toEqual(['Alice']);
+  });
+
+  test("users cannot read or mutate another user's contact", async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const otherSessionId = await createTestSession(ctx);
+
+    const contactId = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Private Contact',
+      email: 'private@example.com',
+    });
+
+    const foreignRead = await ctx.query(api.contact.getContact, {
+      sessionId: otherSessionId,
+      contactId,
+    });
+    expect(foreignRead).toBeNull();
+
+    await expectConvexError(
+      ctx.mutation(api.contact.updateContact, {
+        sessionId: otherSessionId,
+        contactId,
+        name: 'Hacked',
+      }),
+      'UNAUTHORIZED'
+    );
+
+    await expectConvexError(
+      ctx.mutation(api.contact.deleteContact, {
+        sessionId: otherSessionId,
+        contactId,
+      }),
+      'UNAUTHORIZED'
+    );
+
+    const ownerContact = await ctx.run(async (dbCtx) => dbCtx.db.get('contacts', contactId));
+    expect(ownerContact?.name).toBe('Private Contact');
+  });
+
+  test('setGoalContacts creates deduplicated links and replacement removes stale links', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Quarterly Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    const contactA = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Contact A',
+    });
+    const contactB = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Contact B',
+    });
+    const contactC = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Contact C',
+    });
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [contactA, contactB, contactA],
+    });
+
+    let links = await ctx.run(async (dbCtx) => {
+      const goal = await dbCtx.db.get('goals', goalId);
+      if (!goal) throw new Error('Expected goal to exist');
+      return dbCtx.db
+        .query('goalContacts')
+        .withIndex('by_user_and_goal', (q) => q.eq('userId', goal.userId).eq('goalId', goalId))
+        .collect();
+    });
+    expect(links).toHaveLength(2);
+    expect(new Set(links.map((l) => l.contactId))).toEqual(new Set([contactA, contactB]));
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [contactB, contactC],
+    });
+
+    links = await ctx.run(async (dbCtx) => {
+      const goal = await dbCtx.db.get('goals', goalId);
+      if (!goal) throw new Error('Expected goal to exist');
+      return dbCtx.db
+        .query('goalContacts')
+        .withIndex('by_user_and_goal', (q) => q.eq('userId', goal.userId).eq('goalId', goalId))
+        .collect();
+    });
+    expect(links).toHaveLength(2);
+    expect(new Set(links.map((l) => l.contactId))).toEqual(new Set([contactB, contactC]));
+  });
+
+  test('setGoalContacts rejects foreign contacts without partial writes', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const otherSessionId = await createTestSession(ctx);
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'My Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    const ownContact = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Own Contact',
+    });
+    const foreignContact = await ctx.mutation(api.contact.createContact, {
+      sessionId: otherSessionId,
+      name: 'Foreign Contact',
+    });
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [ownContact],
+    });
+
+    await expectConvexError(
+      ctx.mutation(api.contact.setGoalContacts, {
+        sessionId,
+        goalId,
+        contactIds: [ownContact, foreignContact],
+      }),
+      'UNAUTHORIZED'
+    );
+
+    const links = await ctx.run(async (dbCtx) => {
+      const goal = await dbCtx.db.get('goals', goalId);
+      if (!goal) throw new Error('Expected goal to exist');
+      return dbCtx.db
+        .query('goalContacts')
+        .withIndex('by_user_and_goal', (q) => q.eq('userId', goal.userId).eq('goalId', goalId))
+        .collect();
+    });
+    expect(links).toHaveLength(1);
+    expect(links[0]?.contactId).toBe(ownContact);
+  });
+
+  test('setGoalLogContacts creates/replaces links with the same guarantees', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Log Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    const logId = await ctx.mutation(api.goalLogs.createGoalLog, {
+      sessionId,
+      goalId,
+      logDate: Date.now(),
+      content: '<p>Progress update</p>',
+    });
+
+    const contactA = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Log Contact A',
+    });
+    const contactB = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Log Contact B',
+    });
+
+    await ctx.mutation(api.contact.setGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+      contactIds: [contactA, contactA, contactB],
+    });
+
+    let links = await ctx.run(async (dbCtx) => {
+      const log = await dbCtx.db.get('goalLogs', logId);
+      if (!log) throw new Error('Expected goal log to exist');
+      return dbCtx.db
+        .query('goalLogContacts')
+        .withIndex('by_user_and_goal_log', (q) => q.eq('userId', log.userId).eq('goalLogId', logId))
+        .collect();
+    });
+    expect(links).toHaveLength(2);
+
+    await ctx.mutation(api.contact.setGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+      contactIds: [contactB],
+    });
+
+    links = await ctx.run(async (dbCtx) => {
+      const log = await dbCtx.db.get('goalLogs', logId);
+      if (!log) throw new Error('Expected goal log to exist');
+      return dbCtx.db
+        .query('goalLogContacts')
+        .withIndex('by_user_and_goal_log', (q) => q.eq('userId', log.userId).eq('goalLogId', logId))
+        .collect();
+    });
+    expect(links).toHaveLength(1);
+    expect(links[0]?.contactId).toBe(contactB);
+
+    const otherSessionId = await createTestSession(ctx);
+    const foreignContact = await ctx.mutation(api.contact.createContact, {
+      sessionId: otherSessionId,
+      name: 'Foreign Log Contact',
+    });
+
+    await expectConvexError(
+      ctx.mutation(api.contact.setGoalLogContacts, {
+        sessionId,
+        goalLogId: logId,
+        contactIds: [contactB, foreignContact],
+      }),
+      'UNAUTHORIZED'
+    );
+
+    links = await ctx.run(async (dbCtx) => {
+      const log = await dbCtx.db.get('goalLogs', logId);
+      if (!log) throw new Error('Expected goal log to exist');
+      return dbCtx.db
+        .query('goalLogContacts')
+        .withIndex('by_user_and_goal_log', (q) => q.eq('userId', log.userId).eq('goalLogId', logId))
+        .collect();
+    });
+    expect(links).toHaveLength(1);
+    expect(links[0]?.contactId).toBe(contactB);
+  });
+
+  test('getGoalContacts/getGoalLogContacts return sorted linked contacts', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Sorted Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    const logId = await ctx.mutation(api.goalLogs.createGoalLog, {
+      sessionId,
+      goalId,
+      logDate: Date.now(),
+      content: '<p>Log entry</p>',
+    });
+
+    const contactZ = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Zoe',
+    });
+    const contactA = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Anna',
+    });
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [contactZ, contactA],
+    });
+    await ctx.mutation(api.contact.setGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+      contactIds: [contactZ, contactA],
+    });
+
+    const goalContacts = await ctx.query(api.contact.getGoalContacts, { sessionId, goalId });
+    const logContacts = await ctx.query(api.contact.getGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+    });
+
+    expect(goalContacts.map((c) => c.name)).toEqual(['Anna', 'Zoe']);
+    expect(logContacts.map((c) => c.name)).toEqual(['Anna', 'Zoe']);
+  });
+
+  test('deleteContact succeeds when unused and is RESOURCE_IN_USE when linked to either entity type', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const unusedContact = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Unused',
+    });
+    const goalLinkedContact = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Goal Linked',
+    });
+    const logLinkedContact = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Log Linked',
+    });
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Delete Test Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+    const logId = await ctx.mutation(api.goalLogs.createGoalLog, {
+      sessionId,
+      goalId,
+      logDate: Date.now(),
+      content: '<p>Delete test log</p>',
+    });
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [goalLinkedContact],
+    });
+    await ctx.mutation(api.contact.setGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+      contactIds: [logLinkedContact],
+    });
+
+    await ctx.mutation(api.contact.deleteContact, { sessionId, contactId: unusedContact });
+    const deleted = await ctx.run(async (dbCtx) => dbCtx.db.get('contacts', unusedContact));
+    expect(deleted).toBeNull();
+
+    await expectConvexError(
+      ctx.mutation(api.contact.deleteContact, { sessionId, contactId: goalLinkedContact }),
+      'RESOURCE_IN_USE'
+    );
+    await expectConvexError(
+      ctx.mutation(api.contact.deleteContact, { sessionId, contactId: logLinkedContact }),
+      'RESOURCE_IN_USE'
+    );
+  });
+
+  test('getContactWork returns only the linked owned goals/logs and null for a foreign contact', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+    const otherSessionId = await createTestSession(ctx);
+
+    const contactId = await ctx.mutation(api.contact.createContact, {
+      sessionId,
+      name: 'Work Contact',
+    });
+    const foreignContactId = await ctx.mutation(api.contact.createContact, {
+      sessionId: otherSessionId,
+      name: 'Foreign Work Contact',
+    });
+
+    const goalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Work Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+    await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId: otherSessionId,
+      title: 'Other Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    const logId = await ctx.mutation(api.goalLogs.createGoalLog, {
+      sessionId,
+      goalId,
+      logDate: Date.now(),
+      content: '<p>Work log</p>',
+    });
+
+    await ctx.mutation(api.contact.setGoalContacts, {
+      sessionId,
+      goalId,
+      contactIds: [contactId],
+    });
+    await ctx.mutation(api.contact.setGoalLogContacts, {
+      sessionId,
+      goalLogId: logId,
+      contactIds: [contactId],
+    });
+
+    // Link foreign goal to own contact should not appear (foreign goal can't be set by other user)
+    // But verify work only returns owned relations
+    const work = await ctx.query(api.contact.getContactWork, { sessionId, contactId });
+    expect(work?.contact._id).toBe(contactId);
+    expect(work?.goals.map((g) => g._id)).toEqual([goalId]);
+    expect(work?.logs.map((l) => l._id)).toEqual([logId]);
+
+    const foreignWork = await ctx.query(api.contact.getContactWork, {
+      sessionId,
+      contactId: foreignContactId,
+    });
+    expect(foreignWork).toBeNull();
+  });
+});

--- a/services/backend/convex/contact.ts
+++ b/services/backend/convex/contact.ts
@@ -1,0 +1,419 @@
+import { ConvexError, v } from 'convex/values';
+import { SessionIdArg } from 'convex-helpers/server/sessions';
+
+import type { Doc, Id } from './_generated/dataModel';
+import { mutation, query, type MutationCtx, type QueryCtx } from './_generated/server';
+import { requireLogin } from '../src/usecase/requireLogin';
+
+const normalizedOptional = (value: string | null | undefined): string | undefined => {
+  if (value == null) return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+function sortContactsByName(contacts: Doc<'contacts'>[]): Doc<'contacts'>[] {
+  return [...contacts].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// fallow-ignore-next-line complexity
+function matchesContactSearch(contact: Doc<'contacts'>, search: string): boolean {
+  const needle = search.toLowerCase();
+  return (
+    contact.name.toLowerCase().includes(needle) ||
+    (contact.email?.toLowerCase().includes(needle) ?? false) ||
+    (contact.organization?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+async function getOwnedContactForMutation(
+  ctx: MutationCtx,
+  contactId: Id<'contacts'>,
+  userId: Id<'users'>
+): Promise<Doc<'contacts'>> {
+  const contact = await ctx.db.get('contacts', contactId);
+  if (!contact) {
+    throw new ConvexError({ code: 'NOT_FOUND', message: 'Contact not found' });
+  }
+  if (contact.userId !== userId) {
+    throw new ConvexError({
+      code: 'UNAUTHORIZED',
+      message: 'You do not have permission to access this contact',
+    });
+  }
+  return contact;
+}
+
+async function getOwnedGoalForMutation(
+  ctx: MutationCtx,
+  goalId: Id<'goals'>,
+  userId: Id<'users'>
+): Promise<Doc<'goals'>> {
+  const goal = await ctx.db.get('goals', goalId);
+  if (!goal) {
+    throw new ConvexError({ code: 'NOT_FOUND', message: 'Goal not found' });
+  }
+  if (goal.userId !== userId) {
+    throw new ConvexError({
+      code: 'UNAUTHORIZED',
+      message: 'You do not have permission to access this goal',
+    });
+  }
+  return goal;
+}
+
+async function getOwnedGoalLogForMutation(
+  ctx: MutationCtx,
+  goalLogId: Id<'goalLogs'>,
+  userId: Id<'users'>
+): Promise<Doc<'goalLogs'>> {
+  const goalLog = await ctx.db.get('goalLogs', goalLogId);
+  if (!goalLog) {
+    throw new ConvexError({ code: 'NOT_FOUND', message: 'Goal log not found' });
+  }
+  if (goalLog.userId !== userId) {
+    throw new ConvexError({
+      code: 'UNAUTHORIZED',
+      message: 'You do not have permission to access this goal log',
+    });
+  }
+  return goalLog;
+}
+
+async function validateOwnedContacts(
+  ctx: MutationCtx,
+  contactIds: Id<'contacts'>[],
+  userId: Id<'users'>
+): Promise<void> {
+  for (const contactId of contactIds) {
+    await getOwnedContactForMutation(ctx, contactId, userId);
+  }
+}
+
+// fallow-ignore-next-line complexity
+async function replaceGoalContacts(
+  ctx: MutationCtx,
+  userId: Id<'users'>,
+  goalId: Id<'goals'>,
+  contactIds: Id<'contacts'>[]
+): Promise<void> {
+  const uniqueContactIds = [...new Set(contactIds)];
+  await getOwnedGoalForMutation(ctx, goalId, userId);
+  await validateOwnedContacts(ctx, uniqueContactIds, userId);
+
+  const currentLinks = await ctx.db
+    .query('goalContacts')
+    .withIndex('by_user_and_goal', (q) => q.eq('userId', userId).eq('goalId', goalId))
+    .collect();
+
+  const desiredSet = new Set(uniqueContactIds.map((id) => id.toString()));
+  const currentSet = new Set(currentLinks.map((link) => link.contactId.toString()));
+  const now = Date.now();
+
+  for (const link of currentLinks) {
+    if (!desiredSet.has(link.contactId.toString())) {
+      await ctx.db.delete('goalContacts', link._id);
+    }
+  }
+
+  for (const contactId of uniqueContactIds) {
+    if (!currentSet.has(contactId.toString())) {
+      await ctx.db.insert('goalContacts', {
+        userId,
+        goalId,
+        contactId,
+        createdAt: now,
+      });
+    }
+  }
+}
+
+// fallow-ignore-next-line complexity
+async function replaceGoalLogContacts(
+  ctx: MutationCtx,
+  userId: Id<'users'>,
+  goalLogId: Id<'goalLogs'>,
+  contactIds: Id<'contacts'>[]
+): Promise<void> {
+  const uniqueContactIds = [...new Set(contactIds)];
+  await getOwnedGoalLogForMutation(ctx, goalLogId, userId);
+  await validateOwnedContacts(ctx, uniqueContactIds, userId);
+
+  const currentLinks = await ctx.db
+    .query('goalLogContacts')
+    .withIndex('by_user_and_goal_log', (q) => q.eq('userId', userId).eq('goalLogId', goalLogId))
+    .collect();
+
+  const desiredSet = new Set(uniqueContactIds.map((id) => id.toString()));
+  const currentSet = new Set(currentLinks.map((link) => link.contactId.toString()));
+  const now = Date.now();
+
+  for (const link of currentLinks) {
+    if (!desiredSet.has(link.contactId.toString())) {
+      await ctx.db.delete('goalLogContacts', link._id);
+    }
+  }
+
+  for (const contactId of uniqueContactIds) {
+    if (!currentSet.has(contactId.toString())) {
+      await ctx.db.insert('goalLogContacts', {
+        userId,
+        goalLogId,
+        contactId,
+        createdAt: now,
+      });
+    }
+  }
+}
+
+async function getLinkedContactsForGoal(
+  ctx: QueryCtx,
+  userId: Id<'users'>,
+  goalId: Id<'goals'>
+): Promise<Doc<'contacts'>[]> {
+  const goal = await ctx.db.get('goals', goalId);
+  if (!goal || goal.userId !== userId) return [];
+
+  const links = await ctx.db
+    .query('goalContacts')
+    .withIndex('by_user_and_goal', (q) => q.eq('userId', userId).eq('goalId', goalId))
+    .collect();
+
+  const contacts = (
+    await Promise.all(links.map((link) => ctx.db.get('contacts', link.contactId)))
+  ).filter((contact): contact is Doc<'contacts'> => contact !== null && contact.userId === userId);
+
+  return sortContactsByName(contacts);
+}
+
+async function getLinkedContactsForGoalLog(
+  ctx: QueryCtx,
+  userId: Id<'users'>,
+  goalLogId: Id<'goalLogs'>
+): Promise<Doc<'contacts'>[]> {
+  const goalLog = await ctx.db.get('goalLogs', goalLogId);
+  if (!goalLog || goalLog.userId !== userId) return [];
+
+  const links = await ctx.db
+    .query('goalLogContacts')
+    .withIndex('by_user_and_goal_log', (q) => q.eq('userId', userId).eq('goalLogId', goalLogId))
+    .collect();
+
+  const contacts = (
+    await Promise.all(links.map((link) => ctx.db.get('contacts', link.contactId)))
+  ).filter((contact): contact is Doc<'contacts'> => contact !== null && contact.userId === userId);
+
+  return sortContactsByName(contacts);
+}
+
+export const createContact = mutation({
+  args: {
+    ...SessionIdArg,
+    name: v.string(),
+    email: v.optional(v.string()),
+    organization: v.optional(v.string()),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Id<'contacts'>> => {
+    const { sessionId, name, email, organization, notes } = args;
+    const user = await requireLogin(ctx, sessionId);
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new ConvexError({
+        code: 'INVALID_ARGUMENT',
+        message: 'Contact name cannot be empty',
+      });
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert('contacts', {
+      userId: user._id,
+      name: trimmedName,
+      email: normalizedOptional(email),
+      organization: normalizedOptional(organization),
+      notes: normalizedOptional(notes),
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const updateContact = mutation({
+  args: {
+    ...SessionIdArg,
+    contactId: v.id('contacts'),
+    name: v.optional(v.string()),
+    email: v.optional(v.union(v.string(), v.null())),
+    organization: v.optional(v.union(v.string(), v.null())),
+    notes: v.optional(v.union(v.string(), v.null())),
+  },
+  // fallow-ignore-next-line complexity
+  handler: async (ctx, args): Promise<void> => {
+    const { sessionId, contactId, name, email, organization, notes } = args;
+    const user = await requireLogin(ctx, sessionId);
+    await getOwnedContactForMutation(ctx, contactId, user._id);
+
+    const updates: Partial<Doc<'contacts'>> = { updatedAt: Date.now() };
+    if (name !== undefined) {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new ConvexError({
+          code: 'INVALID_ARGUMENT',
+          message: 'Contact name cannot be empty',
+        });
+      }
+      updates.name = trimmedName;
+    }
+    if (email !== undefined) updates.email = normalizedOptional(email);
+    if (organization !== undefined) updates.organization = normalizedOptional(organization);
+    if (notes !== undefined) updates.notes = normalizedOptional(notes);
+
+    await ctx.db.patch('contacts', contactId, updates);
+  },
+});
+
+export const deleteContact = mutation({
+  args: { ...SessionIdArg, contactId: v.id('contacts') },
+  handler: async (ctx, args): Promise<void> => {
+    const { sessionId, contactId } = args;
+    const user = await requireLogin(ctx, sessionId);
+    const userId = user._id;
+    await getOwnedContactForMutation(ctx, contactId, userId);
+
+    const goalLinks = await ctx.db
+      .query('goalContacts')
+      .withIndex('by_user_and_contact', (q) => q.eq('userId', userId).eq('contactId', contactId))
+      .collect();
+    if (goalLinks.length > 0) {
+      throw new ConvexError({
+        code: 'RESOURCE_IN_USE',
+        message: `Cannot delete contact: linked to ${goalLinks.length} goal(s). Remove associations first.`,
+      });
+    }
+
+    const logLinks = await ctx.db
+      .query('goalLogContacts')
+      .withIndex('by_user_and_contact', (q) => q.eq('userId', userId).eq('contactId', contactId))
+      .collect();
+    if (logLinks.length > 0) {
+      throw new ConvexError({
+        code: 'RESOURCE_IN_USE',
+        message: `Cannot delete contact: linked to ${logLinks.length} goal log(s). Remove associations first.`,
+      });
+    }
+
+    await ctx.db.delete('contacts', contactId);
+  },
+});
+
+export const getContacts = query({
+  args: { ...SessionIdArg, search: v.optional(v.string()) },
+  handler: async (ctx, args): Promise<Doc<'contacts'>[]> => {
+    const { sessionId, search } = args;
+    const user = await requireLogin(ctx, sessionId);
+    const contacts = await ctx.db
+      .query('contacts')
+      .withIndex('by_user', (q) => q.eq('userId', user._id))
+      .collect();
+
+    const trimmedSearch = search?.trim();
+    const filtered =
+      trimmedSearch && trimmedSearch.length > 0
+        ? contacts.filter((contact) => matchesContactSearch(contact, trimmedSearch))
+        : contacts;
+
+    return sortContactsByName(filtered);
+  },
+});
+
+export const getContact = query({
+  args: { ...SessionIdArg, contactId: v.id('contacts') },
+  handler: async (ctx, args): Promise<Doc<'contacts'> | null> => {
+    const { sessionId, contactId } = args;
+    const user = await requireLogin(ctx, sessionId);
+    const contact = await ctx.db.get('contacts', contactId);
+    if (!contact || contact.userId !== user._id) return null;
+    return contact;
+  },
+});
+
+export const setGoalContacts = mutation({
+  args: {
+    ...SessionIdArg,
+    goalId: v.id('goals'),
+    contactIds: v.array(v.id('contacts')),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const { sessionId, goalId, contactIds } = args;
+    const user = await requireLogin(ctx, sessionId);
+    await replaceGoalContacts(ctx, user._id, goalId, contactIds);
+  },
+});
+
+export const getGoalContacts = query({
+  args: { ...SessionIdArg, goalId: v.id('goals') },
+  handler: async (ctx, args): Promise<Doc<'contacts'>[]> => {
+    const { sessionId, goalId } = args;
+    const user = await requireLogin(ctx, sessionId);
+    return await getLinkedContactsForGoal(ctx, user._id, goalId);
+  },
+});
+
+export const setGoalLogContacts = mutation({
+  args: {
+    ...SessionIdArg,
+    goalLogId: v.id('goalLogs'),
+    contactIds: v.array(v.id('contacts')),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const { sessionId, goalLogId, contactIds } = args;
+    const user = await requireLogin(ctx, sessionId);
+    await replaceGoalLogContacts(ctx, user._id, goalLogId, contactIds);
+  },
+});
+
+export const getGoalLogContacts = query({
+  args: { ...SessionIdArg, goalLogId: v.id('goalLogs') },
+  handler: async (ctx, args): Promise<Doc<'contacts'>[]> => {
+    const { sessionId, goalLogId } = args;
+    const user = await requireLogin(ctx, sessionId);
+    return await getLinkedContactsForGoalLog(ctx, user._id, goalLogId);
+  },
+});
+
+export type ContactWork = {
+  contact: Doc<'contacts'>;
+  goals: Doc<'goals'>[];
+  logs: Doc<'goalLogs'>[];
+};
+
+export const getContactWork = query({
+  args: { ...SessionIdArg, contactId: v.id('contacts') },
+  handler: async (ctx, args): Promise<ContactWork | null> => {
+    const { sessionId, contactId } = args;
+    const user = await requireLogin(ctx, sessionId);
+    const userId = user._id;
+
+    const contact = await ctx.db.get('contacts', contactId);
+    if (!contact || contact.userId !== userId) return null;
+
+    const goalLinks = await ctx.db
+      .query('goalContacts')
+      .withIndex('by_user_and_contact', (q) => q.eq('userId', userId).eq('contactId', contactId))
+      .collect();
+
+    const logLinks = await ctx.db
+      .query('goalLogContacts')
+      .withIndex('by_user_and_contact', (q) => q.eq('userId', userId).eq('contactId', contactId))
+      .collect();
+
+    const goals = (
+      await Promise.all(goalLinks.map((link) => ctx.db.get('goals', link.goalId)))
+    ).filter((goal): goal is Doc<'goals'> => goal !== null && goal.userId === userId);
+
+    const logs = (
+      await Promise.all(logLinks.map((link) => ctx.db.get('goalLogs', link.goalLogId)))
+    ).filter((log): log is Doc<'goalLogs'> => log !== null && log.userId === userId);
+
+    return { contact, goals, logs };
+  },
+});

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -439,6 +439,39 @@ export default defineSchema({
     .index('by_goal_and_date', ['goalId', 'logDate'])
     .index('by_root_goal_and_date', ['rootGoalId', 'logDate']),
 
+  /**
+   * Contacts - people associated with goals and goal logs.
+   */
+  contacts: defineTable({
+    userId: v.id('users'),
+    name: v.string(),
+    email: v.optional(v.string()),
+    organization: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index('by_user', ['userId']),
+
+  goalContacts: defineTable({
+    userId: v.id('users'),
+    goalId: v.id('goals'),
+    contactId: v.id('contacts'),
+    createdAt: v.number(),
+  })
+    .index('by_user_and_goal', ['userId', 'goalId'])
+    .index('by_user_and_contact', ['userId', 'contactId'])
+    .index('by_user_goal_contact', ['userId', 'goalId', 'contactId']),
+
+  goalLogContacts: defineTable({
+    userId: v.id('users'),
+    goalLogId: v.id('goalLogs'),
+    contactId: v.id('contacts'),
+    createdAt: v.number(),
+  })
+    .index('by_user_and_goal_log', ['userId', 'goalLogId'])
+    .index('by_user_and_contact', ['userId', 'contactId'])
+    .index('by_user_goal_log_contact', ['userId', 'goalLogId', 'contactId']),
+
   // ============================================================================
   // DOCUMENTS TABLE
   // ============================================================================


### PR DESCRIPTION
## Summary
- Parks the in-progress **Contact Management and Tagging** feature on a draft PR for later resume.
- **Done:** Phase 1 backend (Convex contacts domain + associations) and Phase 2 contact management UI (`/app/contacts`).
- **Remaining:** Phases 3–7 (goal/log tagging, quarterly review lookup, markdown mentions, polish) — full slice plan in `docs/plans/005-contact-management-and-tagging/`.

## Implementation plan
See the plan docs included in this PR:
- [Overview](docs/plans/005-contact-management-and-tagging/overview.md)
- [PRD](docs/plans/005-contact-management-and-tagging/prd.md)
- [Phases / slices](docs/plans/005-contact-management-and-tagging/phases.md) — all original planned slices with status

| Phase | Description | Status |
| ----- | ----------- | ------ |
| 1 | Convex contacts domain and associations | Complete |
| 2 | Contact management UI | In progress (UI landed; full suite verify pending) |
| 3 | Goal contact tagging | Pending |
| 4 | Goal log contact tagging | Pending |
| 5 | Quarterly review contact lookup | Pending |
| 6 | Markdown contact mentions | Pending |
| 7 | Integration verification and polish | Pending |

## Test plan
- [ ] Resume from Phase 3 when ready
- [ ] Run backend contact tests (`contact.spec.ts`)
- [ ] Run webapp contact form/dialog tests
- [ ] Typecheck backend + webapp before marking ready for review
- [ ] Do **not** merge until Phases 3–7 are complete (or consciously scoped down)


Made with [Cursor](https://cursor.com)