### PR TITLE
fix(pull-goals): From/To week chooser, live preview, and Jump

### DIFF
--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
@@ -109,4 +109,20 @@ describe('PullGoalsPreviewDialog', () => {
     const confirmButton = screen.getByRole('button', { name: /Pulling/i });
     expect(confirmButton).toBeDisabled();
   });
+
+  it('still shows From week when Jump lands on a week missing from weekOptions', () => {
+    renderDialog({
+      fromWeek: { year: 2026, quarter: 3, weekNumber: 26 },
+      toWeek: { year: 2026, quarter: 3, weekNumber: 29 },
+      weekOptions: [
+        { year: 2026, quarter: 3, weekNumber: 27, label: 'Week 27 (past)' },
+        { year: 2026, quarter: 3, weekNumber: 28, label: 'Week 28 (past)' },
+        { year: 2026, quarter: 3, weekNumber: 29, label: 'Week 29 (current)' },
+      ],
+    });
+
+    // The Select must display "Week 26" even though 26 is not in weekOptions,
+    // because the dialog appends a synthetic option for the current fromWeek.
+    expect(screen.getByText('Week 26')).toBeInTheDocument();
+  });
 });

--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PullGoalsPreviewDialog } from './PullGoalsPreviewDialog';
+
+const baseWeekOptions = [
+  { year: 2026, quarter: 2, weekNumber: 10, label: 'Week 10 (past)' },
+  { year: 2026, quarter: 2, weekNumber: 11, label: 'Week 11 (past)' },
+  { year: 2026, quarter: 2, weekNumber: 12, label: 'Week 12 (current)' },
+];
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof PullGoalsPreviewDialog>> = {}
+) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    fromWeek: { year: 2026, quarter: 2, weekNumber: 11 },
+    toWeek: { year: 2026, quarter: 2, weekNumber: 12 },
+    tasksFromPreviousWeek: [],
+    tasksFromPastDays: [],
+    showPastDaysSection: true,
+    todayLabel: 'Wednesday',
+    isRefreshingPreview: false,
+    isPulling: false,
+    weekOptions: baseWeekOptions,
+    onFromWeekChange: vi.fn(),
+    onToWeekChange: vi.fn(),
+    onJumpToLastNonEmpty: vi.fn(),
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<PullGoalsPreviewDialog {...props} />), props };
+}
+
+describe('PullGoalsPreviewDialog', () => {
+  it('renders From/To controls, Jump, and section headings', () => {
+    renderDialog({
+      tasksFromPreviousWeek: [
+        {
+          id: 't1',
+          title: 'Carry task',
+          quarterlyGoal: { id: 'q1', title: 'Q Goal' },
+          weeklyGoal: { id: 'w1', title: 'W Goal' },
+        },
+      ],
+      tasksFromPastDays: [
+        {
+          id: 't2',
+          title: 'Past day task',
+          quarterlyGoal: { id: 'q1', title: 'Q Goal' },
+          weeklyGoal: { id: 'w1', title: 'W Goal' },
+        },
+      ],
+    });
+
+    expect(screen.getByText('Pull Incomplete Goals')).toBeInTheDocument();
+    expect(screen.getByText(/Week 11 → Week 12/)).toBeInTheDocument();
+    expect(screen.getByText(/Past days → Wednesday/)).toBeInTheDocument();
+    expect(screen.getByText('Carry task')).toBeInTheDocument();
+    expect(screen.getByText('Past day task')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Jump/i })).toBeInTheDocument();
+  });
+
+  it('disables Pull Goals when there are no tasks', () => {
+    renderDialog();
+
+    expect(screen.getByRole('button', { name: /Pull Goals/i })).toBeDisabled();
+    expect(screen.getByText(/Nothing to pull for this range/i)).toBeInTheDocument();
+  });
+
+  it('calls onJumpToLastNonEmpty when Jump is clicked', () => {
+    const { props } = renderDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: /Jump/i }));
+
+    expect(props.onJumpToLastNonEmpty).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides past-days section when showPastDaysSection is false', () => {
+    renderDialog({
+      showPastDaysSection: false,
+      tasksFromPreviousWeek: [
+        {
+          id: 't1',
+          title: 'Carry task',
+          quarterlyGoal: { id: 'q1', title: 'Q Goal' },
+          weeklyGoal: { id: 'w1', title: 'W Goal' },
+        },
+      ],
+    });
+
+    expect(screen.queryByText(/Past days →/)).not.toBeInTheDocument();
+  });
+
+  it('disables Confirm when isPulling is true', () => {
+    renderDialog({
+      isPulling: true,
+      tasksFromPreviousWeek: [
+        {
+          id: 't1',
+          title: 'Carry task',
+          quarterlyGoal: { id: 'q1', title: 'Q Goal' },
+          weeklyGoal: { id: 'w1', title: 'W Goal' },
+        },
+      ],
+    });
+
+    const confirmButton = screen.getByRole('button', { name: /Pulling/i });
+    expect(confirmButton).toBeDisabled();
+  });
+});

--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
@@ -1,0 +1,395 @@
+import { History, Loader2, Pin, Search, Star } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+// ── Shared types ────────────────────────────────────────────────────────────
+
+/** A week reference within a specific year/quarter. */
+export type WeekRef = {
+  year: number;
+  quarter: number;
+  weekNumber: number;
+};
+
+/** A task item rendered in the preview list. */
+export interface PreviewTask {
+  id: string;
+  title: string;
+  details?: string;
+  quarterlyGoal: {
+    id: string;
+    title: string;
+    isStarred?: boolean;
+    isPinned?: boolean;
+  };
+  weeklyGoal: {
+    id: string;
+    title: string;
+  };
+  children?: PreviewTask[];
+  depth?: number;
+}
+
+/** A week option returned by `api.goal.getAvailableWeeks`. */
+interface WeekOption {
+  year: number;
+  quarter: number;
+  weekNumber: number;
+  label: string;
+}
+
+// ── Props ────────────────────────────────────────────────────────────────────
+
+export interface PullGoalsPreviewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fromWeek: WeekRef | null;
+  toWeek: WeekRef;
+  tasksFromPreviousWeek: PreviewTask[];
+  tasksFromPastDays: PreviewTask[];
+  /** True when To is calendar current week and past-days pull applies. */
+  showPastDaysSection: boolean;
+  /** Display name for today (e.g. "Wednesday") when past-days section shown. */
+  todayLabel: string;
+  isRefreshingPreview: boolean;
+  isPulling: boolean;
+  /** Week options for the current To quarter. */
+  weekOptions: WeekOption[];
+  onFromWeekChange: (week: WeekRef) => void;
+  onToWeekChange: (week: WeekRef) => void;
+  onJumpToLastNonEmpty: () => void;
+  onConfirm: () => void;
+}
+
+// ── Local helpers ────────────────────────────────────────────────────────────
+
+/** Recursive task item renderer. */
+function TaskPreviewItem({ task, depth = 0 }: { task: PreviewTask; depth?: number }) {
+  return (
+    <>
+      <li className="flex items-center gap-2" style={{ paddingLeft: `${(depth + 1) * 16}px` }}>
+        <span className="h-2 w-2 rounded-full bg-blue-500 shrink-0" />
+        <div className="text-sm break-words">{task.title}</div>
+      </li>
+      {task.children &&
+        task.children.length > 0 &&
+        task.children.map((child) => (
+          <TaskPreviewItem key={child.id} task={child} depth={depth + 1} />
+        ))}
+    </>
+  );
+}
+
+/** Group tasks by quarterly → weekly, same structure as TaskMovePreview. */
+interface QuarterlyGroup {
+  quarterlyGoal: {
+    id: string;
+    title: string;
+    isStarred?: boolean;
+    isPinned?: boolean;
+  };
+  weeklyGoals: Record<
+    string,
+    {
+      weeklyGoal: { id: string; title: string };
+      tasks: PreviewTask[];
+    }
+  >;
+}
+
+function groupTasks(tasks: PreviewTask[]): Record<string, QuarterlyGroup> {
+  return tasks.reduce(
+    (acc, task) => {
+      const quarterlyId = task.quarterlyGoal.id;
+      const weeklyId = task.weeklyGoal.id;
+
+      if (!acc[quarterlyId]) {
+        acc[quarterlyId] = {
+          quarterlyGoal: task.quarterlyGoal,
+          weeklyGoals: {},
+        };
+      }
+      if (!acc[quarterlyId].weeklyGoals[weeklyId]) {
+        acc[quarterlyId].weeklyGoals[weeklyId] = {
+          weeklyGoal: task.weeklyGoal,
+          tasks: [],
+        };
+      }
+      acc[quarterlyId].weeklyGoals[weeklyId].tasks.push(task);
+      return acc;
+    },
+    {} as Record<string, QuarterlyGroup>
+  );
+}
+
+/** Render a grouped task list. */
+function TaskGroupList({ tasks }: { tasks: PreviewTask[] }) {
+  const grouped = groupTasks(tasks);
+
+  return (
+    <div className="space-y-4">
+      {Object.values(grouped).map((quarterlyGroup) => (
+        <div key={quarterlyGroup.quarterlyGoal.id} className="space-y-2">
+          <h4 className="flex items-center gap-1.5 text-sm font-medium">
+            {quarterlyGroup.quarterlyGoal.isStarred && (
+              <Star className="h-3.5 w-3.5 fill-yellow-400 text-yellow-400" />
+            )}
+            {quarterlyGroup.quarterlyGoal.isPinned && (
+              <Pin className="h-3.5 w-3.5 fill-blue-400 text-blue-400" />
+            )}
+            <div className="rounded-md px-2 py-1 text-sm font-semibold text-foreground break-words">
+              {quarterlyGroup.quarterlyGoal.title}
+            </div>
+          </h4>
+          <div
+            className={cn(
+              'overflow-hidden rounded-md',
+              quarterlyGroup.quarterlyGoal.isStarred
+                ? 'border border-yellow-200 bg-yellow-50'
+                : quarterlyGroup.quarterlyGoal.isPinned
+                  ? 'border border-blue-200 bg-blue-50'
+                  : ''
+            )}
+          >
+            {Object.values(quarterlyGroup.weeklyGoals).map((weeklyGroup) => (
+              <div key={weeklyGroup.weeklyGoal.id} className="space-y-1 py-2 pl-4">
+                <h5 className="text-sm text-muted-foreground">
+                  <div className="rounded-md px-2 py-1 text-sm font-semibold text-foreground break-words">
+                    {weeklyGroup.weeklyGoal.title}
+                  </div>
+                </h5>
+                <ul className="space-y-1">
+                  {weeklyGroup.tasks.map((task) => (
+                    <TaskPreviewItem key={task.id} task={task} />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function PullGoalsPreviewDialog(props: PullGoalsPreviewDialogProps) {
+  const {
+    open,
+    onOpenChange,
+    fromWeek,
+    toWeek,
+    tasksFromPreviousWeek,
+    tasksFromPastDays,
+    showPastDaysSection,
+    todayLabel,
+    isRefreshingPreview,
+    isPulling,
+    weekOptions,
+    onFromWeekChange,
+    onToWeekChange,
+    onJumpToLastNonEmpty,
+    onConfirm,
+  } = props;
+
+  const totalTasks = tasksFromPreviousWeek.length + tasksFromPastDays.length;
+
+  // ── Week option filtering ─────────────────────────────────────────────────
+  // From options: all weeks strictly before the selected To week
+  const fromOptions = weekOptions.filter((w) => w.weekNumber < toWeek.weekNumber);
+  // To options: all available weeks in the quarter
+  const toOptions = weekOptions;
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
+  const handleFromChange = (weekNumberStr: string) => {
+    const weekNumber = parseInt(weekNumberStr, 10);
+    const match = weekOptions.find((w) => w.weekNumber === weekNumber);
+    if (match) {
+      onFromWeekChange({
+        year: match.year,
+        quarter: match.quarter,
+        weekNumber: match.weekNumber,
+      });
+    }
+  };
+
+  const handleToChange = (weekNumberStr: string) => {
+    const weekNumber = parseInt(weekNumberStr, 10);
+    const match = weekOptions.find((w) => w.weekNumber === weekNumber);
+    if (match) {
+      onToWeekChange({
+        year: match.year,
+        quarter: match.quarter,
+        weekNumber: match.weekNumber,
+      });
+    }
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="flex max-h-[90vh] flex-col">
+        {/* ── Header ──────────────────────────────────────────────────────── */}
+        <AlertDialogHeader className="shrink-0">
+          <AlertDialogTitle>Pull Incomplete Goals</AlertDialogTitle>
+          <AlertDialogDescription>
+            Choose which week to pull from and to. Incomplete goals will be moved (not copied).
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {/* ── Controls ────────────────────────────────────────────────────── */}
+        <div className="shrink-0 space-y-3">
+          {/* From row */}
+          <div className="flex items-end gap-3">
+            <div className="flex-1 space-y-1">
+              <Label>From week</Label>
+              <Select
+                value={fromWeek ? String(fromWeek.weekNumber) : ''}
+                onValueChange={handleFromChange}
+                disabled={fromOptions.length === 0}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="No prior week" />
+                </SelectTrigger>
+                <SelectContent>
+                  {fromOptions.map((option) => (
+                    <SelectItem key={option.weekNumber} value={String(option.weekNumber)}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onJumpToLastNonEmpty}
+              disabled={isRefreshingPreview || isPulling}
+              className="shrink-0"
+            >
+              {isRefreshingPreview ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Search className="mr-1 h-3.5 w-3.5" />
+              )}
+              Jump
+            </Button>
+          </div>
+
+          {/* To row */}
+          <div className="space-y-1">
+            <Label>To week</Label>
+            <Select value={String(toWeek.weekNumber)} onValueChange={handleToChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {toOptions.map((option) => (
+                  <SelectItem key={option.weekNumber} value={String(option.weekNumber)}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* ── Preview body ────────────────────────────────────────────────── */}
+        <div className="relative min-h-0 flex-1 overflow-y-auto pr-2 -mr-2">
+          {/* Loading overlay */}
+          {isRefreshingPreview && totalTasks > 0 && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-background/60">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {totalTasks === 0 && !isRefreshingPreview ? (
+            <div className="py-8 text-center text-muted-foreground">
+              <History className="mx-auto mb-4 h-12 w-12 opacity-50" />
+              <p>Nothing to pull for this range.</p>
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'space-y-6',
+                isRefreshingPreview && 'opacity-50 transition-opacity'
+              )}
+            >
+              {/* Section A: Week pull */}
+              {fromWeek && (
+                <section>
+                  <h3 className="mb-2 text-sm font-semibold text-foreground">
+                    Week {fromWeek.weekNumber} → Week {toWeek.weekNumber}
+                  </h3>
+                  {tasksFromPreviousWeek.length > 0 ? (
+                    <TaskGroupList tasks={tasksFromPreviousWeek} />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No incomplete goals in this week.
+                    </p>
+                  )}
+                </section>
+              )}
+
+              {/* Section B: Past days → today */}
+              {showPastDaysSection && (
+                <section>
+                  <h3 className="mb-2 text-sm font-semibold text-foreground">
+                    Past days → {todayLabel}
+                  </h3>
+                  {tasksFromPastDays.length > 0 ? (
+                    <TaskGroupList tasks={tasksFromPastDays} />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No incomplete goals from past days.
+                    </p>
+                  )}
+                </section>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Footer ──────────────────────────────────────────────────────── */}
+        <AlertDialogFooter className="shrink-0">
+          <AlertDialogCancel disabled={isPulling}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={totalTasks === 0 || isPulling || isRefreshingPreview}
+          >
+            {isPulling ? (
+              <>
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                Pulling...
+              </>
+            ) : (
+              'Pull Goals'
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
@@ -215,8 +215,23 @@ export function PullGoalsPreviewDialog(props: PullGoalsPreviewDialogProps) {
   const totalTasks = tasksFromPreviousWeek.length + tasksFromPastDays.length;
 
   // ── Week option filtering ─────────────────────────────────────────────────
-  // From options: all weeks strictly before the selected To week
-  const fromOptions = weekOptions.filter((w) => w.weekNumber < toWeek.weekNumber);
+  // From options: all weeks strictly before the selected To week.
+  // If fromWeek is set but no option has that weekNumber, append a synthetic
+  // option so the Select control never goes blank (e.g. Jump returns a week
+  // outside the quarter's week list, or an old week the quarter didn't include).
+  const fromOptionsBase = weekOptions.filter((w) => w.weekNumber < toWeek.weekNumber);
+  const fromOptions =
+    fromWeek && !fromOptionsBase.some((w) => w.weekNumber === fromWeek.weekNumber)
+      ? [
+          ...fromOptionsBase,
+          {
+            year: fromWeek.year,
+            quarter: fromWeek.quarter,
+            weekNumber: fromWeek.weekNumber,
+            label: `Week ${fromWeek.weekNumber}`,
+          },
+        ].sort((a, b) => a.weekNumber - b.weekNumber)
+      : fromOptionsBase;
   // To options: all available weeks in the quarter
   const toOptions = weekOptions;
 

--- a/apps/webapp/src/hooks/usePullGoals.tsx
+++ b/apps/webapp/src/hooks/usePullGoals.tsx
@@ -1,16 +1,16 @@
 import { api } from '@workspace/backend/convex/_generated/api';
 import { DayOfWeek } from '@workspace/backend/src/constants';
-import { useMutation } from 'convex/react';
+import { useMutation, useQuery } from 'convex/react';
 import { useConvex } from 'convex/react';
 import { type ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useGoalActions } from './useGoalActions';
 
 import {
+  PullGoalsPreviewDialog,
   type PreviewTask,
-  TaskMovePreview,
-  type TaskMovePreviewData,
-} from '@/components/molecules/day-of-week/components/TaskMovePreview';
+  type WeekRef,
+} from '@/components/molecules/PullGoalsPreviewDialog';
 import { toast } from '@/components/ui/use-toast';
 import { useCurrentWeekInfo } from '@/hooks/useCurrentDateTime';
 import { getDayName } from '@/lib/constants';
@@ -21,12 +21,6 @@ interface UsePullGoalsProps {
   year: number;
   quarter: number;
 }
-
-type WeekRef = {
-  year: number;
-  quarter: number;
-  weekNumber: number;
-};
 
 interface PullGoalsPreviewData {
   tasksFromPreviousWeek: PreviewTask[];
@@ -99,17 +93,19 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
   // --- State ---
   const [isPulling, setIsPulling] = useState(false);
   const [isRefreshingPreview, setIsRefreshingPreview] = useState(false);
-  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [preview, setPreview] = useState<TaskMovePreviewData | null>(null);
+  const [showDialog, setShowDialog] = useState(false);
   const [previewData, setPreviewData] = useState<PullGoalsPreviewData | null>(null);
 
   // Editable From/To state (initialised lazily when dialog opens)
   const [fromWeek, setFromWeekState] = useState<WeekRef | null>(null);
   const [toWeek, setToWeekState] = useState<WeekRef | null>(null);
 
-  // Stable refs for the preview/execute helpers
+  // Stable refs for the preview/execute helpers (avoid stale closure reads)
   const fromWeekRef = useRef<WeekRef | null>(null);
   const toWeekRef = useRef<WeekRef | null>(null);
+
+  // Current effective To (derived from state or default)
+  const effectiveToWeek: WeekRef = toWeek ?? toDefault;
 
   const updateFromWeek = useCallback((week: WeekRef | null) => {
     setFromWeekState(week);
@@ -120,6 +116,16 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     setToWeekState(week);
     toWeekRef.current = week;
   }, []);
+
+  // --- Week options for dialog selects ---
+  const weekOptions = useQuery(api.goal.getAvailableWeeks, {
+    sessionId,
+    currentWeek: {
+      year: effectiveToWeek.year,
+      quarter: effectiveToWeek.quarter,
+      weekNumber: effectiveToWeek.weekNumber,
+    },
+  });
 
   // --- Helpers ---
 
@@ -249,6 +255,33 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
   );
 
   /**
+   * Refresh the preview from the current From/To refs.
+   * Used after setFromWeek / setToWeek / jump changes.
+   */
+  const refreshPreview = useCallback(async () => {
+    const from = fromWeekRef.current;
+    const to = toWeekRef.current ?? toDefault;
+
+    setIsRefreshingPreview(true);
+    try {
+      const [weekTasks, pastDayTasks] = await Promise.all([
+        previewWeekPull(from, to),
+        previewPastDays(to),
+      ]);
+
+      setPreviewData({
+        tasksFromPreviousWeek: weekTasks,
+        tasksFromPastDays: pastDayTasks,
+        totalTasks: weekTasks.length + pastDayTasks.length,
+      });
+    } catch (error) {
+      console.error('Failed to refresh preview:', error);
+    } finally {
+      setIsRefreshingPreview(false);
+    }
+  }, [toDefault, previewWeekPull, previewPastDays]);
+
+  /**
    * Reset From/To to defaults, run preview, and open dialog.
    * Always opens the dialog (even if totalTasks === 0).
    */
@@ -268,33 +301,14 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
         previewPastDays(to),
       ]);
 
-      const allTasks = [...weekTasks, ...pastDayTasks];
-      const total = allTasks.length;
-
       setPreviewData({
         tasksFromPreviousWeek: weekTasks,
         tasksFromPastDays: pastDayTasks,
-        totalTasks: total,
-      });
-
-      // Build description for the dialog
-      let previousDayDescription = '';
-      if (weekTasks.length > 0 && pastDayTasks.length > 0) {
-        previousDayDescription = 'previous week and past days';
-      } else if (weekTasks.length > 0) {
-        previousDayDescription = 'previous week';
-      } else {
-        previousDayDescription = 'past days';
-      }
-
-      setPreview({
-        previousDay: previousDayDescription,
-        targetDay: getDayName(currentDayOfWeek),
-        tasks: allTasks,
+        totalTasks: weekTasks.length + pastDayTasks.length,
       });
 
       // ALWAYS open dialog (even if 0 tasks)
-      setShowConfirmDialog(true);
+      setShowDialog(true);
     } catch (error) {
       console.error('Failed to preview goals:', error);
       toast({
@@ -305,7 +319,7 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     } finally {
       setIsPulling(false);
     }
-  }, [fromDefault, toDefault, updateFromWeek, updateToWeek, previewWeekPull, previewPastDays, currentDayOfWeek]);
+  }, [fromDefault, toDefault, updateFromWeek, updateToWeek, previewWeekPull, previewPastDays]);
 
   /**
    * Execute the pull goals operation for the current From/To range.
@@ -353,7 +367,7 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
         }
       }
 
-      setShowConfirmDialog(false);
+      setShowDialog(false);
     } catch (error) {
       console.error('Failed to pull goals:', error);
       toast({
@@ -376,26 +390,34 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
   // ---- Public setters for slice 2 ----
 
   const setFromWeek = useCallback(
-    (week: WeekRef) => {
+    async (week: WeekRef) => {
       updateFromWeek(week);
-      // Preview refresh happens in the next render — we could trigger it here
-      // but the caller in slice 2 will manage preview refresh via a useEffect.
+      await refreshPreview();
     },
-    [updateFromWeek]
+    [updateFromWeek, refreshPreview]
   );
 
   const setToWeek = useCallback(
-    (week: WeekRef) => {
-      // If new To is <= current From, clamp/clear From
+    async (week: WeekRef) => {
       const currentFrom = fromWeekRef.current;
-      if (currentFrom && currentFrom.weekNumber >= week.weekNumber) {
-        // Clear From when To is moved to same or earlier week
-        updateFromWeek(currentFrom.weekNumber > 1 ? { ...week, weekNumber: currentFrom.weekNumber - 1 } : null);
+      const sameQuarter =
+        currentFrom &&
+        currentFrom.year === week.year &&
+        currentFrom.quarter === week.quarter;
+
+      // Clamp/clear From if it would be >= To
+      if (!sameQuarter || !currentFrom || currentFrom.weekNumber >= week.weekNumber) {
+        updateFromWeek(
+          week.weekNumber > 1
+            ? { year: week.year, quarter: week.quarter, weekNumber: week.weekNumber - 1 }
+            : null
+        );
       }
 
       updateToWeek(week);
+      await refreshPreview();
     },
-    [updateFromWeek, updateToWeek]
+    [updateFromWeek, updateToWeek, refreshPreview]
   );
 
   const jumpToLastNonEmptyWeek = useCallback(async () => {
@@ -411,6 +433,17 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
 
       if (result) {
         updateFromWeek(result);
+        // Refresh preview with the new From
+        const fromVal = result;
+        const [weekTasks, pastDayTasks] = await Promise.all([
+          previewWeekPull(fromVal, to),
+          previewPastDays(to),
+        ]);
+        setPreviewData({
+          tasksFromPreviousWeek: weekTasks,
+          tasksFromPastDays: pastDayTasks,
+          totalTasks: weekTasks.length + pastDayTasks.length,
+        });
       } else {
         toast({
           title: 'No earlier week found',
@@ -427,7 +460,7 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     } finally {
       setIsRefreshingPreview(false);
     }
-  }, [sessionId, convex, updateFromWeek]);
+  }, [sessionId, convex, updateFromWeek, previewWeekPull, previewPastDays]);
 
   return {
     isPulling,
@@ -435,16 +468,27 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     pendingGoalsCount: previewData?.totalTasks ?? 0,
     handlePullGoals,
     fromWeek,
-    toWeek: toWeek ?? toDefault,
+    toWeek: effectiveToWeek,
     setFromWeek,
     setToWeek,
     jumpToLastNonEmptyWeek,
     isRefreshingPreview,
     dialog: (
-      <TaskMovePreview
-        open={showConfirmDialog}
-        onOpenChange={setShowConfirmDialog}
-        preview={preview}
+      <PullGoalsPreviewDialog
+        open={showDialog}
+        onOpenChange={setShowDialog}
+        fromWeek={fromWeek}
+        toWeek={effectiveToWeek}
+        tasksFromPreviousWeek={previewData?.tasksFromPreviousWeek ?? []}
+        tasksFromPastDays={previewData?.tasksFromPastDays ?? []}
+        showPastDaysSection={shouldPullPastDays(effectiveToWeek)}
+        todayLabel={getDayName(currentDayOfWeek)}
+        isRefreshingPreview={isRefreshingPreview}
+        isPulling={isPulling}
+        weekOptions={weekOptions ?? []}
+        onFromWeekChange={setFromWeek}
+        onToWeekChange={setToWeek}
+        onJumpToLastNonEmpty={jumpToLastNonEmptyWeek}
         onConfirm={executePullGoals}
       />
     ),

--- a/apps/webapp/src/hooks/usePullGoals.tsx
+++ b/apps/webapp/src/hooks/usePullGoals.tsx
@@ -1,7 +1,8 @@
 import { api } from '@workspace/backend/convex/_generated/api';
 import { DayOfWeek } from '@workspace/backend/src/constants';
 import { useMutation } from 'convex/react';
-import { type ReactElement, useCallback, useState } from 'react';
+import { useConvex } from 'convex/react';
+import { type ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useGoalActions } from './useGoalActions';
 
@@ -11,7 +12,7 @@ import {
   type TaskMovePreviewData,
 } from '@/components/molecules/day-of-week/components/TaskMovePreview';
 import { toast } from '@/components/ui/use-toast';
-import { useCurrentDateInfo } from '@/hooks/useCurrentDateTime';
+import { useCurrentWeekInfo } from '@/hooks/useCurrentDateTime';
 import { getDayName } from '@/lib/constants';
 import { useSession } from '@/modules/auth/useSession';
 
@@ -20,6 +21,12 @@ interface UsePullGoalsProps {
   year: number;
   quarter: number;
 }
+
+type WeekRef = {
+  year: number;
+  quarter: number;
+  weekNumber: number;
+};
 
 interface PullGoalsPreviewData {
   tasksFromPreviousWeek: PreviewTask[];
@@ -33,39 +40,89 @@ interface UsePullGoalsReturn {
   pendingGoalsCount: number;
   handlePullGoals: () => Promise<void>;
   dialog: ReactElement;
+  /** The current From week (null when week 1 / no prior week in quarter). */
+  fromWeek: WeekRef | null;
+  /** The current To week (defaults to calendar current week). */
+  toWeek: WeekRef;
+  /** Update From week and refresh preview. */
+  setFromWeek: (week: WeekRef) => void;
+  /** Update To week, clamp/clear From if invalid, and refresh preview. */
+  setToWeek: (week: WeekRef) => void;
+  /** Jump From to the last non-empty week before the current To week (same quarter only). */
+  jumpToLastNonEmptyWeek: () => Promise<void>;
+  /** True while a Jump query or preview refresh is in flight. */
+  isRefreshingPreview: boolean;
 }
 
 /**
  * Unified hook for pulling goals from:
- * 1. Last non-empty week → Monday of current week
+ * 1. Previous week → Monday of target week (explicit From/To, never moveGoalsFromLastNonEmptyWeek)
  * 2. Past days of current week → Today
  *
- * This combines both operations into a single "Pull goals" action.
+ * Props are kept for caller compat but IGNORED for defaults/execution.
+ * Defaults come from `useCurrentWeekInfo()`.
  */
-export const usePullGoals = ({
-  weekNumber,
-  year,
-  quarter,
-}: UsePullGoalsProps): UsePullGoalsReturn => {
+export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
   const { sessionId } = useSession();
   const { moveGoalsFromDay } = useGoalActions();
-  const moveGoalsFromLastNonEmptyWeekMutation = useMutation(api.goal.moveGoalsFromLastNonEmptyWeek);
+  const moveGoalsFromWeekMutation = useMutation(api.goal.moveGoalsFromWeek);
+  const convex = useConvex();
 
+  // Calendar current week — source of truth for defaults
+  const {
+    weekNumber: currentWeekNumber,
+    weekYear,
+    weekQuarter,
+    weekday: currentDayOfWeek,
+  } = useCurrentWeekInfo();
+
+  const isMonday = currentDayOfWeek === DayOfWeek.MONDAY;
+
+  // --- Derived defaults (stable across renders) ---
+  const toDefault = useMemo<WeekRef>(
+    () => ({
+      year: weekYear,
+      quarter: weekQuarter,
+      weekNumber: currentWeekNumber,
+    }),
+    [weekYear, weekQuarter, currentWeekNumber]
+  );
+
+  const fromDefault = useMemo<WeekRef | null>(
+    () =>
+      currentWeekNumber > 1
+        ? { year: weekYear, quarter: weekQuarter, weekNumber: currentWeekNumber - 1 }
+        : null,
+    [currentWeekNumber, weekYear, weekQuarter]
+  );
+
+  // --- State ---
   const [isPulling, setIsPulling] = useState(false);
+  const [isRefreshingPreview, setIsRefreshingPreview] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [preview, setPreview] = useState<TaskMovePreviewData | null>(null);
   const [previewData, setPreviewData] = useState<PullGoalsPreviewData | null>(null);
 
-  // Get current day info
-  const { weekday: currentDayOfWeek } = useCurrentDateInfo();
+  // Editable From/To state (initialised lazily when dialog opens)
+  const [fromWeek, setFromWeekState] = useState<WeekRef | null>(null);
+  const [toWeek, setToWeekState] = useState<WeekRef | null>(null);
 
-  // Check if it's Monday (first day of week)
-  const isMonday = currentDayOfWeek === DayOfWeek.MONDAY;
+  // Stable refs for the preview/execute helpers
+  const fromWeekRef = useRef<WeekRef | null>(null);
+  const toWeekRef = useRef<WeekRef | null>(null);
 
-  // Check if it's the first week of the quarter (don't pull from previous quarter)
-  const isFirstWeekOfQuarter = weekNumber === 1;
+  const updateFromWeek = useCallback((week: WeekRef | null) => {
+    setFromWeekState(week);
+    fromWeekRef.current = week;
+  }, []);
 
-  // Get all past days of the current week (before today)
+  const updateToWeek = useCallback((week: WeekRef) => {
+    setToWeekState(week);
+    toWeekRef.current = week;
+  }, []);
+
+  // --- Helpers ---
+
   const getPastDaysOfWeek = useCallback((): DayOfWeek[] => {
     const pastDays: DayOfWeek[] = [];
     for (let day = DayOfWeek.MONDAY; day < currentDayOfWeek; day++) {
@@ -74,175 +131,220 @@ export const usePullGoals = ({
     return pastDays;
   }, [currentDayOfWeek]);
 
-  /**
-   * Preview what goals would be pulled (dry-run)
-   */
-  const handlePreviewGoals = useCallback(async (): Promise<PullGoalsPreviewData | null> => {
-    const allTasksFromPreviousWeek: PreviewTask[] = [];
-    const allTasksFromPastDays: PreviewTask[] = [];
+  /** Determine whether past-days preview/execute applies (To == calendar current week && not Monday). */
+  const shouldPullPastDays = useCallback(
+    (to: WeekRef): boolean => {
+      return (
+        !isMonday &&
+        to.year === weekYear &&
+        to.quarter === weekQuarter &&
+        to.weekNumber === currentWeekNumber
+      );
+    },
+    [isMonday, weekYear, weekQuarter, currentWeekNumber]
+  );
 
-    try {
-      // Step 1: Preview goals from last non-empty week → Monday
-      // IMPORTANT: Only pull from previous weeks within the same quarter (not from previous quarter)
-      if (!isFirstWeekOfQuarter) {
-        const weekPreviewData = await moveGoalsFromLastNonEmptyWeekMutation({
-          sessionId,
+  /**
+   * Preview the week pull for a given From → To range.
+   * Returns the list of tasks from the week pull (empty list if none or invalid range).
+   */
+  const previewWeekPull = useCallback(
+    async (from: WeekRef | null, to: WeekRef): Promise<PreviewTask[]> => {
+      if (!from || from.weekNumber >= to.weekNumber) return [];
+
+      const result = await moveGoalsFromWeekMutation({
+        sessionId,
+        from,
+        to: { ...to, dayOfWeek: DayOfWeek.MONDAY },
+        dryRun: true,
+      });
+
+      if (!('canPull' in result) || !result.canPull) return [];
+
+      const weekTasks: PreviewTask[] = result.dailyGoalsToMove.map((dailyGoal) => {
+        const quarterlyStatus = result.quarterlyGoalsToUpdate.find(
+          (q) => q.id === dailyGoal.quarterlyGoalId
+        ) ?? { isStarred: false, isPinned: false };
+
+        return {
+          id: dailyGoal.id,
+          title: dailyGoal.title,
+          isComplete: false,
+          quarterlyGoal: {
+            id: dailyGoal.quarterlyGoalId ?? dailyGoal.weeklyGoalId,
+            title: dailyGoal.quarterlyGoalTitle ?? dailyGoal.weeklyGoalTitle,
+            isStarred: quarterlyStatus.isStarred,
+            isPinned: quarterlyStatus.isPinned,
+          },
+          weeklyGoal: {
+            id: dailyGoal.weeklyGoalId,
+            title: dailyGoal.weeklyGoalTitle,
+          },
+        };
+      });
+
+      // Also add adhoc goals from the preview
+      if (result.adhocGoalsToMove && result.adhocGoalsToMove.length > 0) {
+        const adhocTasks: PreviewTask[] = result.adhocGoalsToMove.map((adhoc) => ({
+          id: adhoc.id,
+          title: adhoc.title,
+          details: undefined,
+          isComplete: false,
+          quarterlyGoal: {
+            id: 'adhoc',
+            title: 'Adhoc Tasks',
+            isStarred: false,
+            isPinned: false,
+          },
+          weeklyGoal: {
+            id: `adhoc-domain-${adhoc.domainId || 'uncategorized'}`,
+            title: adhoc.domainName || 'Uncategorized',
+          },
+        }));
+        weekTasks.push(...adhocTasks);
+      }
+
+      return weekTasks;
+    },
+    [sessionId, moveGoalsFromWeekMutation]
+  );
+
+  /**
+   * Preview past-days pull for a target week.
+   * Only applies when `to` matches the calendar current week and today is not Monday.
+   */
+  const previewPastDays = useCallback(
+    async (to: WeekRef): Promise<PreviewTask[]> => {
+      if (!shouldPullPastDays(to)) return [];
+
+      const tasks: PreviewTask[] = [];
+      const pastDays = getPastDaysOfWeek();
+
+      for (const pastDay of pastDays) {
+        const dayPreviewData = await moveGoalsFromDay({
+          from: {
+            year: to.year,
+            quarter: to.quarter,
+            weekNumber: to.weekNumber,
+            dayOfWeek: pastDay,
+          },
           to: {
-            quarter,
-            weekNumber,
-            year,
-            dayOfWeek: DayOfWeek.MONDAY, // Always pull to Monday first
+            year: to.year,
+            quarter: to.quarter,
+            weekNumber: to.weekNumber,
+            dayOfWeek: currentDayOfWeek,
           },
           dryRun: true,
+          moveOnlyIncomplete: true,
         });
 
-        if ('canPull' in weekPreviewData && weekPreviewData.canPull) {
-          // Convert daily goals from week preview to PreviewTask format
-          const weekTasks = weekPreviewData.dailyGoalsToMove.map((dailyGoal) => {
-            const quarterlyStatus = weekPreviewData.quarterlyGoalsToUpdate.find(
-              (q) => q.id === dailyGoal.quarterlyGoalId
-            ) ?? { isStarred: false, isPinned: false };
-
-            return {
-              id: dailyGoal.id,
-              title: dailyGoal.title,
-              isComplete: false,
-              quarterlyGoal: {
-                id: dailyGoal.quarterlyGoalId ?? dailyGoal.weeklyGoalId,
-                title: dailyGoal.quarterlyGoalTitle ?? dailyGoal.weeklyGoalTitle,
-                isStarred: quarterlyStatus.isStarred,
-                isPinned: quarterlyStatus.isPinned,
-              },
-              weeklyGoal: {
-                id: dailyGoal.weeklyGoalId,
-                title: dailyGoal.weeklyGoalTitle,
-              },
-            };
-          });
-          allTasksFromPreviousWeek.push(...weekTasks);
-
-          // Also add adhoc goals from the preview
-          if (weekPreviewData.adhocGoalsToMove && weekPreviewData.adhocGoalsToMove.length > 0) {
-            const adhocTasks = weekPreviewData.adhocGoalsToMove.map((adhoc) => ({
-              id: adhoc.id,
-              title: adhoc.title,
-              details: undefined,
-              isComplete: false,
-              quarterlyGoal: {
-                id: 'adhoc',
-                title: 'Adhoc Tasks',
-                isStarred: false,
-                isPinned: false,
-              },
-              weeklyGoal: {
-                id: `adhoc-domain-${adhoc.domainId || 'uncategorized'}`,
-                title: adhoc.domainName || 'Uncategorized',
-              },
-            }));
-            allTasksFromPreviousWeek.push(...adhocTasks);
-          }
+        if ('canMove' in dayPreviewData && dayPreviewData.canMove && dayPreviewData.tasks.length > 0) {
+          tasks.push(...dayPreviewData.tasks);
         }
       }
 
-      // Step 2: Preview goals from past days in current week → Today
-      // NOTE: Adhoc goals are week-level (not day-level), so they don't need to be
-      // "pulled" from past days - they're already in the current week.
-      // Only regular daily goals need to be moved between days.
-      if (!isMonday) {
-        const pastDays = getPastDaysOfWeek();
-
-        for (const pastDay of pastDays) {
-          // Preview regular goals from this past day
-          const dayPreviewData = await moveGoalsFromDay({
-            from: {
-              year,
-              quarter,
-              weekNumber,
-              dayOfWeek: pastDay,
-            },
-            to: {
-              year,
-              quarter,
-              weekNumber,
-              dayOfWeek: currentDayOfWeek,
-            },
-            dryRun: true,
-            moveOnlyIncomplete: true,
-          });
-
-          if (
-            'canMove' in dayPreviewData &&
-            dayPreviewData.canMove &&
-            dayPreviewData.tasks.length > 0
-          ) {
-            allTasksFromPastDays.push(...dayPreviewData.tasks);
-          }
-        }
-      }
-
-      return {
-        tasksFromPreviousWeek: allTasksFromPreviousWeek,
-        tasksFromPastDays: allTasksFromPastDays,
-        totalTasks: allTasksFromPreviousWeek.length + allTasksFromPastDays.length,
-      };
-    } catch (error) {
-      console.error('Failed to preview goals:', error);
-      return null;
-    }
-  }, [
-    sessionId,
-    quarter,
-    weekNumber,
-    year,
-    isMonday,
-    isFirstWeekOfQuarter,
-    currentDayOfWeek,
-    getPastDaysOfWeek,
-    moveGoalsFromLastNonEmptyWeekMutation,
-    moveGoalsFromDay,
-  ]);
+      return tasks;
+    },
+    [shouldPullPastDays, getPastDaysOfWeek, moveGoalsFromDay, currentDayOfWeek]
+  );
 
   /**
-   * Execute the pull goals operation
+   * Reset From/To to defaults, run preview, and open dialog.
+   * Always opens the dialog (even if totalTasks === 0).
    */
-  const executePullGoals = useCallback(async () => {
+  const handlePullGoals = useCallback(async () => {
     try {
       setIsPulling(true);
 
-      // Step 1: Pull from last non-empty week → Monday
-      // IMPORTANT: Only pull from previous weeks within the same quarter (not from previous quarter)
-      if (!isFirstWeekOfQuarter) {
-        await moveGoalsFromLastNonEmptyWeekMutation({
+      // Reset to defaults from calendar
+      const from = fromDefault;
+      const to = toDefault;
+      updateFromWeek(from);
+      updateToWeek(to);
+
+      // Run preview
+      const [weekTasks, pastDayTasks] = await Promise.all([
+        previewWeekPull(from, to),
+        previewPastDays(to),
+      ]);
+
+      const allTasks = [...weekTasks, ...pastDayTasks];
+      const total = allTasks.length;
+
+      setPreviewData({
+        tasksFromPreviousWeek: weekTasks,
+        tasksFromPastDays: pastDayTasks,
+        totalTasks: total,
+      });
+
+      // Build description for the dialog
+      let previousDayDescription = '';
+      if (weekTasks.length > 0 && pastDayTasks.length > 0) {
+        previousDayDescription = 'previous week and past days';
+      } else if (weekTasks.length > 0) {
+        previousDayDescription = 'previous week';
+      } else {
+        previousDayDescription = 'past days';
+      }
+
+      setPreview({
+        previousDay: previousDayDescription,
+        targetDay: getDayName(currentDayOfWeek),
+        tasks: allTasks,
+      });
+
+      // ALWAYS open dialog (even if 0 tasks)
+      setShowConfirmDialog(true);
+    } catch (error) {
+      console.error('Failed to preview goals:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to preview goals to pull.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPulling(false);
+    }
+  }, [fromDefault, toDefault, updateFromWeek, updateToWeek, previewWeekPull, previewPastDays, currentDayOfWeek]);
+
+  /**
+   * Execute the pull goals operation for the current From/To range.
+   * Uses moveGoalsFromWeek with explicit from/to (never moveGoalsFromLastNonEmptyWeek).
+   */
+  const executePullGoals = useCallback(async () => {
+    const from = fromWeekRef.current;
+    const to = toWeekRef.current;
+    if (!to) return;
+
+    try {
+      setIsPulling(true);
+
+      // Step 1: Week pull (if valid range)
+      if (from && from.weekNumber < to.weekNumber) {
+        await moveGoalsFromWeekMutation({
           sessionId,
-          to: {
-            quarter,
-            weekNumber,
-            year,
-            dayOfWeek: DayOfWeek.MONDAY,
-          },
+          from,
+          to: { ...to, dayOfWeek: DayOfWeek.MONDAY },
           dryRun: false,
         });
       }
 
-      // Step 2: Pull from past days → Today
-      // NOTE: Adhoc goals are week-level, so they don't need day-to-day movement.
-      // Only regular daily goals are moved between days.
-      if (!isMonday) {
+      // Step 2: Past-days pull (if applicable)
+      if (shouldPullPastDays(to)) {
         const pastDays = getPastDaysOfWeek();
 
         for (const pastDay of pastDays) {
-          // Move regular goals only
           await moveGoalsFromDay({
             from: {
-              year,
-              quarter,
-              weekNumber,
+              year: to.year,
+              quarter: to.quarter,
+              weekNumber: to.weekNumber,
               dayOfWeek: pastDay,
             },
             to: {
-              year,
-              quarter,
-              weekNumber,
+              year: to.year,
+              quarter: to.quarter,
+              weekNumber: to.weekNumber,
               dayOfWeek: currentDayOfWeek,
             },
             dryRun: false,
@@ -264,70 +366,80 @@ export const usePullGoals = ({
     }
   }, [
     sessionId,
-    quarter,
-    weekNumber,
-    year,
-    isMonday,
-    isFirstWeekOfQuarter,
-    currentDayOfWeek,
-    getPastDaysOfWeek,
-    moveGoalsFromLastNonEmptyWeekMutation,
+    moveGoalsFromWeekMutation,
     moveGoalsFromDay,
+    shouldPullPastDays,
+    getPastDaysOfWeek,
+    currentDayOfWeek,
   ]);
 
-  /**
-   * Main handler: Preview first, then show dialog
-   */
-  const handlePullGoals = useCallback(async () => {
+  // ---- Public setters for slice 2 ----
+
+  const setFromWeek = useCallback(
+    (week: WeekRef) => {
+      updateFromWeek(week);
+      // Preview refresh happens in the next render — we could trigger it here
+      // but the caller in slice 2 will manage preview refresh via a useEffect.
+    },
+    [updateFromWeek]
+  );
+
+  const setToWeek = useCallback(
+    (week: WeekRef) => {
+      // If new To is <= current From, clamp/clear From
+      const currentFrom = fromWeekRef.current;
+      if (currentFrom && currentFrom.weekNumber >= week.weekNumber) {
+        // Clear From when To is moved to same or earlier week
+        updateFromWeek(currentFrom.weekNumber > 1 ? { ...week, weekNumber: currentFrom.weekNumber - 1 } : null);
+      }
+
+      updateToWeek(week);
+    },
+    [updateFromWeek, updateToWeek]
+  );
+
+  const jumpToLastNonEmptyWeek = useCallback(async () => {
+    const to = toWeekRef.current;
+    if (!to) return;
+
+    setIsRefreshingPreview(true);
     try {
-      setIsPulling(true);
-      const previewResult = await handlePreviewGoals();
-
-      if (!previewResult || previewResult.totalTasks === 0) {
-        return;
-      }
-
-      setPreviewData(previewResult);
-
-      // Combine all tasks for the preview dialog
-      const allTasks = [...previewResult.tasksFromPreviousWeek, ...previewResult.tasksFromPastDays];
-
-      // Build description based on what's being pulled
-      let previousDayDescription = '';
-      if (
-        previewResult.tasksFromPreviousWeek.length > 0 &&
-        previewResult.tasksFromPastDays.length > 0
-      ) {
-        previousDayDescription = 'previous week and past days';
-      } else if (previewResult.tasksFromPreviousWeek.length > 0) {
-        previousDayDescription = 'previous week';
-      } else {
-        previousDayDescription = 'past days';
-      }
-
-      setPreview({
-        previousDay: previousDayDescription,
-        targetDay: getDayName(currentDayOfWeek),
-        tasks: allTasks,
+      const result = await convex.query(api.goal.findLastNonEmptyWeekBefore, {
+        sessionId,
+        before: to,
       });
-      setShowConfirmDialog(true);
+
+      if (result) {
+        updateFromWeek(result);
+      } else {
+        toast({
+          title: 'No earlier week found',
+          description: 'No earlier week with incomplete goals in this quarter.',
+        });
+      }
     } catch (error) {
-      console.error('Failed to preview goals:', error);
+      console.error('Failed to find last non-empty week:', error);
       toast({
         title: 'Error',
-        description: 'Failed to preview goals to pull.',
+        description: 'Failed to find earlier week.',
         variant: 'destructive',
       });
     } finally {
-      setIsPulling(false);
+      setIsRefreshingPreview(false);
     }
-  }, [handlePreviewGoals, currentDayOfWeek]);
+  }, [sessionId, convex, updateFromWeek]);
 
   return {
     isPulling,
     hasPendingGoals: (previewData?.totalTasks ?? 0) > 0,
     pendingGoalsCount: previewData?.totalTasks ?? 0,
     handlePullGoals,
+    fromWeek,
+    toWeek: toWeek ?? toDefault,
+    setFromWeek,
+    setToWeek,
+    jumpToLastNonEmptyWeek,
+    isRefreshingPreview,
     dialog: (
       <TaskMovePreview
         open={showConfirmDialog}

--- a/apps/webapp/src/hooks/usePullGoals.tsx
+++ b/apps/webapp/src/hooks/usePullGoals.tsx
@@ -1,5 +1,6 @@
 import { api } from '@workspace/backend/convex/_generated/api';
 import { DayOfWeek } from '@workspace/backend/src/constants';
+import { getQuarterWeeks } from '@workspace/backend/src/usecase/quarter';
 import { useMutation, useQuery } from 'convex/react';
 import { useConvex } from 'convex/react';
 import { type ReactElement, useCallback, useMemo, useRef, useState } from 'react';
@@ -82,13 +83,14 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     [weekYear, weekQuarter, currentWeekNumber]
   );
 
-  const fromDefault = useMemo<WeekRef | null>(
-    () =>
-      currentWeekNumber > 1
-        ? { year: weekYear, quarter: weekQuarter, weekNumber: currentWeekNumber - 1 }
-        : null,
-    [currentWeekNumber, weekYear, weekQuarter]
-  );
+  const fromDefault = useMemo<WeekRef | null>(() => {
+    const { weeks } = getQuarterWeeks(weekYear, weekQuarter);
+    const prior = weeks.filter((w) => w < currentWeekNumber);
+    if (prior.length === 0) return null;
+    // Largest week still before current week number
+    const weekNumber = prior[prior.length - 1];
+    return { year: weekYear, quarter: weekQuarter, weekNumber };
+  }, [currentWeekNumber, weekYear, weekQuarter]);
 
   // --- State ---
   const [isPulling, setIsPulling] = useState(false);

--- a/docs/public/pulling-goals.md
+++ b/docs/public/pulling-goals.md
@@ -13,25 +13,40 @@ When starting a new quarter, you can pull incomplete goals from the previous qua
 
 This will copy the selected goals to your current quarter, allowing you to continue working on them.
 
-## Pulling from Previous Weeks
+## Pull Incomplete Goals (weeks and past days)
 
-Similarly, when starting a new week, you can pull incomplete goals from the previous week:
+Use **Pull Goals** from the daily/weekly focus toolbar (or the current week card) when you want to continue unfinished work.
 
-1. Navigate to the Weekly Goals view
-2. Click on "Pull from Previous Week"
-3. Select which incomplete goals you want to bring forward
-4. Click "Pull Selected Goals"
+### How it works
 
-## Pulling from Previous Days
+1. Click **Pull Goals**
+2. A dialog opens with:
+   - **From week** — defaults to the previous calendar week
+   - **To week** — defaults to the current calendar week
+   - **Jump** — sets From to the last earlier week in the **same quarter** that still has incomplete work (useful after a holiday gap)
+   - A live preview of everything that will move for the selected range
+3. Review the preview:
+   - **Week N → Week M** — incomplete goals/adhoc tasks pulled from From → To (land on Monday of To)
+   - **Past days → today** — when To is the current week and today is not Monday, incomplete tasks from earlier days this week also move to today
+4. Click **Pull Goals** to confirm (or Cancel)
 
-For daily planning, you can pull incomplete tasks from the previous day:
+Goals are **moved**, not copied. The preview list is view-only — change From/To (or Jump) to control what is included.
 
-1. Navigate to the Daily Goals view
-2. Click on "Pull from Yesterday"
-3. Select which incomplete tasks you want to bring forward
-4. Click "Pull Selected Tasks"
+### Defaults and stale weeks
 
-This feature helps ensure continuity in your daily planning and prevents important tasks from falling through the cracks.
+- Defaults always use the **current calendar week**, not whichever week you happen to be browsing in the UI.
+- If the default range is empty, the dialog still opens so you can pick another From/To.
+
+### Limitations
+
+- Jump only searches earlier weeks in the **same quarter** (it will not jump into the previous quarter).
+- Past-days pull only runs when To is the current calendar week and today is not Monday.
+- Only incomplete work is moved; completed items stay put.
+
+### Tips
+
+- After time away, open Pull Goals and use **Jump** to pick up from the last week that still has incomplete work.
+- Continuing work is the main goal — prefer adjusting From/To over recreating tasks.
 
 ## Pulling from Previous Day
 
@@ -54,9 +69,3 @@ You can pull incomplete tasks from the previous day to the current day. This is 
 - Use this feature at the start of your day to bring forward any unfinished tasks
 - Tasks maintain their association with their weekly and quarterly goals when moved
 - The original task is moved (not copied), maintaining a single source of truth
-
-## Coming Soon: Pulling from Previous Week
-
-> This section describes functionality that will be available in a future update.
-
-The ability to pull tasks from the previous week will provide more flexibility in managing tasks across longer time periods.

--- a/services/backend/convex/goal.spec.ts
+++ b/services/backend/convex/goal.spec.ts
@@ -332,6 +332,91 @@ describe('moveGoalsFromWeek', () => {
     expect(fireGoalsAfter).toContain(carriedOverWeeklyGoal?._id);
     expect(fireGoalsAfter).toHaveLength(1); // Should only have the new goal, not the old one
   });
+
+  test('only pulls the latest snapshot in a carry-over series', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // Create quarterly + weekly goals at week 1
+    const quarterlyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Quarterly);
+    const weeklyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Weekly, quarterlyGoalId);
+
+    // -- Build series: week1 → week2 → week3 (three snapshots, same rootGoalId) --
+    await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 1 },
+      to: { year: 2024, quarter: 1, weekNumber: 2 },
+      dryRun: false,
+    });
+    await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 2 },
+      to: { year: 2024, quarter: 1, weekNumber: 3 },
+      dryRun: false,
+    });
+
+    // -- Older snapshot (week 1) must NOT be pullable into week 4 --
+    const stalePreview = (await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 1 },
+      to: { year: 2024, quarter: 1, weekNumber: 4 },
+      dryRun: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    })) as any;
+
+    // The stale clone must not appear in weekStatesToCopy
+    expect(stalePreview.weekStatesToCopy).toEqual([]);
+    // canPull must be false since the only weekly goal in week 1 is the stale series clone
+    // (adhocGoalsToMove is empty, dailyGoalsToMove is empty)
+    expect(stalePreview.canPull).toBe(false);
+
+    // -- Latest snapshot (week 3) MUST still be pullable into week 4 --
+    const latestPreview = (await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 3 },
+      to: { year: 2024, quarter: 1, weekNumber: 4 },
+      dryRun: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    })) as any;
+
+    expect(latestPreview.canPull).toBe(true);
+    expect(latestPreview.weekStatesToCopy).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: 'Goal weekly',
+          carryOver: expect.objectContaining({
+            fromGoal: expect.objectContaining({ rootGoalId: weeklyGoalId }),
+          }),
+        }),
+      ])
+    );
+
+    // -- Execute latest pull and confirm a single new clone lands in week 4 --
+    await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 3 },
+      to: { year: 2024, quarter: 1, weekNumber: 4 },
+      dryRun: false,
+    });
+
+    const weekFour = await ctx.query(api.dashboard.getWeek, {
+      sessionId,
+      year: 2024,
+      quarter: 1,
+      weekNumber: 4,
+    });
+
+    const qg = weekFour.tree.quarterlyGoals.find(
+      (g: GoalWithDetailsAndChildren) => g._id === quarterlyGoalId
+    );
+    const seriesClonesInWeek4 = (qg?.children ?? []).filter(
+      (wg: GoalWithDetailsAndChildren) =>
+        wg.carryOver?.fromGoal.rootGoalId === weeklyGoalId
+    );
+
+    // Only ONE clone in week 4 (from the latest snapshot, not the two earlier ones)
+    expect(seriesClonesInWeek4).toHaveLength(1);
+  });
 });
 
 describe('moveGoalsFromDay', () => {

--- a/services/backend/convex/goal.spec.ts
+++ b/services/backend/convex/goal.spec.ts
@@ -1159,3 +1159,104 @@ describe('deleteGoal', () => {
     expect(weeklyGoals.length).toBe(0);
   });
 });
+
+describe('findLastNonEmptyWeekBefore', () => {
+  test('returns the most recent earlier week in the same quarter with goal state', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // Create a quarterly goal → creates goalStateByWeek entries for ALL weeks in Q1 2024
+    const quarterlyGoalId = await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Q1 Quarterly',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    // Create a weekly goal at week 2 (adds a goalStateByWeek entry for week 2 specifically)
+    await ctx.mutation(api.dashboard.createWeeklyGoal, {
+      sessionId,
+      title: 'Week 2 Goal',
+      parentId: quarterlyGoalId,
+      weekNumber: 2,
+    });
+
+    // Also create a weekly goal at week 4
+    await ctx.mutation(api.dashboard.createWeeklyGoal, {
+      sessionId,
+      title: 'Week 4 Goal',
+      parentId: quarterlyGoalId,
+      weekNumber: 4,
+    });
+
+    // Query: find the most recent week before week 5
+    const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
+      sessionId,
+      before: { year: 2024, quarter: 1, weekNumber: 5 },
+    });
+
+    // The loop searches from weekNumber-1 = 4 down to 1.
+    // All weeks have quarterly goal states so week 4 is found first.
+    expect(result).toEqual({ year: 2024, quarter: 1, weekNumber: 4 });
+  });
+
+  test('returns null when no earlier week in the quarter has content', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // No goals created at all → no goalStateByWeek entries
+
+    const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
+      sessionId,
+      before: { year: 2024, quarter: 1, weekNumber: 3 },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test('does not cross into the previous quarter', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // Create a quarterly goal only in 2023 Q4 → goalStateByWeek entries only for Q4 2023 weeks
+    await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Q4 2023 Goal',
+      year: 2023,
+      quarter: 4,
+      weekNumber: 12,
+    });
+
+    // Query for 2024 Q1 week 2 with NO content in Q1 2024
+    const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
+      sessionId,
+      before: { year: 2024, quarter: 1, weekNumber: 2 },
+    });
+
+    // Must NOT cross into Q4 2023 → should return null
+    expect(result).toBeNull();
+  });
+
+  test('returns null when before.weekNumber is 1 (no prior week in quarter)', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // Create a quarterly goal in Q1 2024
+    await ctx.mutation(api.dashboard.createQuarterlyGoal, {
+      sessionId,
+      title: 'Q1 Goal',
+      year: 2024,
+      quarter: 1,
+      weekNumber: 1,
+    });
+
+    // before week 1 → loop doesn't run (candidateWeek = 0, 0 >= 1 is false)
+    const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
+      sessionId,
+      before: { year: 2024, quarter: 1, weekNumber: 1 },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/services/backend/convex/goal.spec.ts
+++ b/services/backend/convex/goal.spec.ts
@@ -1336,12 +1336,35 @@ describe('findLastNonEmptyWeekBefore', () => {
       weekNumber: 1,
     });
 
-    // before week 1 → loop doesn't run (candidateWeek = 0, 0 >= 1 is false)
+    // before week 1 → candidates list is empty (no Q1 weeks < 1)
     const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
       sessionId,
       before: { year: 2024, quarter: 1, weekNumber: 1 },
     });
 
+    expect(result).toBeNull();
+  });
+
+  test('does not jump to a week outside the current quarter (e.g. week 26 when To is early Q3)', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    // Create an incomplete adhoc goal in week 26 of 2026 (prior quarter territory).
+    // This must NOT lure the finder when searching Q3 weeks.
+    await ctx.mutation(api.adhocGoal.createAdhocGoal, {
+      sessionId,
+      title: 'Adhoc in Q2 week 26',
+      year: 2026,
+      weekNumber: 26,
+    });
+
+    // Query for Q3 week 27 with NO regular/adhoc content in any Q3 week
+    const result = await ctx.query(api.goal.findLastNonEmptyWeekBefore, {
+      sessionId,
+      before: { year: 2026, quarter: 3, weekNumber: 27 },
+    });
+
+    // Must NOT return week 26 (which belongs to Q2, not Q3)
     expect(result).toBeNull();
   });
 });

--- a/services/backend/convex/goal.ts
+++ b/services/backend/convex/goal.ts
@@ -186,6 +186,60 @@ export const getAvailableWeeks = query({
   },
 });
 
+/**
+ * Find the most recent week before `before` (same year+quarter only) that has
+ * movable incomplete content (regular week states and/or incomplete adhoc goals).
+ * Returns null if none found within the quarter.
+ */
+export const findLastNonEmptyWeekBefore = query({
+  args: {
+    ...SessionIdArg,
+    before: v.object({
+      year: v.number(),
+      quarter: v.number(),
+      weekNumber: v.number(),
+    }),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireLogin(ctx, args.sessionId);
+    const userId = user._id;
+    const { year, quarter, weekNumber } = args.before;
+
+    // Search weekNumber-1 down to 1 in the SAME quarter only
+    for (let candidateWeek = weekNumber - 1; candidateWeek >= 1; candidateWeek--) {
+      // Cheap existence probe: check for both regular goals and adhoc goals
+      const [regularGoalProbe, adhocGoalProbe] = await Promise.all([
+        ctx.db
+          .query('goalStateByWeek')
+          .withIndex('by_user_and_year_and_quarter_and_week', (q) =>
+            q
+              .eq('userId', userId)
+              .eq('year', year)
+              .eq('quarter', quarter)
+              .eq('weekNumber', candidateWeek)
+          )
+          .first(),
+        ctx.db
+          .query('goals')
+          .withIndex('by_user_and_adhoc_year_week', (q) =>
+            q
+              .eq('userId', userId)
+              .eq('year', year)
+              .eq('adhoc.weekNumber', candidateWeek)
+          )
+          .filter((q) => q.eq(q.field('isComplete'), false))
+          .first(),
+      ]);
+
+      if (regularGoalProbe || adhocGoalProbe) {
+        return { year, quarter, weekNumber: candidateWeek };
+      }
+    }
+
+    return null;
+  },
+});
+
 export const moveGoalsFromDay = mutation({
   args: {
     ...SessionIdArg,

--- a/services/backend/convex/goal.ts
+++ b/services/backend/convex/goal.ts
@@ -205,8 +205,14 @@ export const findLastNonEmptyWeekBefore = query({
     const userId = user._id;
     const { year, quarter, weekNumber } = args.before;
 
-    // Search weekNumber-1 down to 1 in the SAME quarter only
-    for (let candidateWeek = weekNumber - 1; candidateWeek >= 1; candidateWeek--) {
+    // Only consider weeks that actually exist in this quarter (from getQuarterWeeks)
+    // and are strictly before the given weekNumber. Search descending (most recent first).
+    const { weeks } = getQuarterWeeks(year, quarter);
+    const candidates = weeks
+      .filter((w) => w < weekNumber)
+      .sort((a, b) => b - a);
+
+    for (const candidateWeek of candidates) {
       // Cheap existence probe: check for both regular goals and adhoc goals
       const [regularGoalProbe, adhocGoalProbe] = await Promise.all([
         ctx.db

--- a/services/backend/src/usecase/moveGoalsFromWeek/moveGoalsFromWeek.ts
+++ b/services/backend/src/usecase/moveGoalsFromWeek/moveGoalsFromWeek.ts
@@ -104,6 +104,52 @@ export async function moveGoalsFromWeekUsecase<T extends MoveGoalsFromWeekArgs>(
   // Pre-fetch goals for the target week (needed for both dry run and actual move)
   const targetWeekGoals = await getGoalsForWeek(ctx, userId, to);
 
+  // --- Filter stale carry-over snapshots ---
+  // When a goal has been carried over across multiple weeks (a series), only the
+  // latest snapshot in the series should be pullable. Older clones must not be
+  // pulled again even if they still exist in the from-week.
+  if (result.weekStatesToCopy.length > 0) {
+    // Query all goal states in weeks after `from` within the same year+quarter
+    const newerStates = await ctx.db
+      .query('goalStateByWeek')
+      .withIndex('by_user_and_year_and_quarter_and_week', (q) =>
+        q
+          .eq('userId', userId)
+          .eq('year', from.year)
+          .eq('quarter', from.quarter)
+      )
+      .filter((q) => q.gt(q.field('weekNumber'), from.weekNumber))
+      .collect();
+
+    // Collect rootGoalIds that have a newer snapshot
+    const rootGoalIdsWithNewerSnapshot = new Set<Id<'goals'>>();
+    for (const state of newerStates) {
+      const rootId = state.carryOver?.fromGoal?.rootGoalId;
+      if (rootId) {
+        rootGoalIdsWithNewerSnapshot.add(rootId);
+      }
+    }
+
+    if (rootGoalIdsWithNewerSnapshot.size > 0) {
+      const staleWeeklyGoalIds = new Set<Id<'goals'>>();
+      result.weekStatesToCopy = result.weekStatesToCopy.filter((item) => {
+        const rootGoalId = item.carryOver.fromGoal.rootGoalId;
+        if (rootGoalIdsWithNewerSnapshot.has(rootGoalId)) {
+          staleWeeklyGoalIds.add(item.originalGoal._id);
+          return false;
+        }
+        return true;
+      });
+
+      // Also exclude daily goals belonging to the filtered-out weekly snapshots
+      if (staleWeeklyGoalIds.size > 0) {
+        result.dailyGoalsToMove = result.dailyGoalsToMove.filter(
+          (item) => !staleWeeklyGoalIds.has(item.parentWeeklyGoal._id)
+        );
+      }
+    }
+  }
+
   // If this is a dry run, return the preview data
   if (dryRun) {
     return (await generateDryRunPreview(


### PR DESCRIPTION
## Summary
- Replaces opaque auto last-non-empty pull with an explicit From/To week dialog and live preview of what will move.
- Defaults From = previous calendar week → To = current calendar week (fixes stale selected-week binding).
- Adds Jump to last non-empty week (same quarter only) for holiday catch-up; keeps past-days → today when To is the current week.
- Adds `findLastNonEmptyWeekBefore` query, dialog UI, tests, and docs aligned with real behavior.
- **Carry-over series:** when a weekly goal has been cloned across weeks (same `rootGoalId`), only the **latest** snapshot is pullable — older incomplete clones are excluded from preview and execute.

## Test plan
- [ ] Open Pull Goals on current week → dialog defaults to previous → current calendar week
- [ ] Change From/To → preview list refreshes; Confirm disabled when empty
- [ ] Click Jump after a gap week → From moves to last non-empty week in quarter; preview updates
- [ ] Mid-week: preview shows past-days → today section; confirm moves both week + past-day items
- [ ] Day-header "Pull Incomplete" still works unchanged
- [ ] After pulling the same weekly goal across multiple weeks, setting From to an older week does not re-pull the stale clone; From = latest week still pulls
- [ ] `pnpm typecheck` and package tests pass