### PR TITLE
fix(pull-goals): Jump tooltip and outside-click dismiss

### DIFF
--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
@@ -125,4 +125,30 @@ describe('PullGoalsPreviewDialog', () => {
     // because the dialog appends a synthetic option for the current fromWeek.
     expect(screen.getByText('Week 26')).toBeInTheDocument();
   });
+
+  it('shows a tooltip describing what Jump does', async () => {
+    renderDialog();
+
+    const jumpButton = screen.getByRole('button', { name: /Jump/i });
+    fireEvent.pointerMove(jumpButton);
+    fireEvent.focus(jumpButton);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.textContent).toMatch(
+      /Jump to the last earlier week in this quarter that still has incomplete goals/i
+    );
+  });
+
+  it('dismisses when the overlay outside the modal is clicked', () => {
+    const { props } = renderDialog();
+
+    const overlay = document.querySelector('[data-slot="alert-dialog-overlay"]');
+    expect(overlay).toBeTruthy();
+    if (!overlay) {
+      throw new Error('Expected alert-dialog overlay to be present');
+    }
+    fireEvent.click(overlay);
+
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 // ── Shared types ────────────────────────────────────────────────────────────
@@ -265,7 +266,10 @@ export function PullGoalsPreviewDialog(props: PullGoalsPreviewDialogProps) {
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent className="flex max-h-[90vh] flex-col">
+      <AlertDialogContent
+        className="flex max-h-[90vh] flex-col"
+        onOverlayClick={() => onOpenChange(false)}
+      >
         {/* ── Header ──────────────────────────────────────────────────────── */}
         <AlertDialogHeader className="shrink-0">
           <AlertDialogTitle>Pull Incomplete Goals</AlertDialogTitle>
@@ -297,20 +301,29 @@ export function PullGoalsPreviewDialog(props: PullGoalsPreviewDialogProps) {
                 </SelectContent>
               </Select>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onJumpToLastNonEmpty}
-              disabled={isRefreshingPreview || isPulling}
-              className="shrink-0"
-            >
-              {isRefreshingPreview ? (
-                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Search className="mr-1 h-3.5 w-3.5" />
-              )}
-              Jump
-            </Button>
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onJumpToLastNonEmpty}
+                    disabled={isRefreshingPreview || isPulling}
+                    className="shrink-0"
+                  >
+                    {isRefreshingPreview ? (
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Search className="mr-1 h-3.5 w-3.5" />
+                    )}
+                    Jump
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs text-center">
+                  Jump to the last earlier week in this quarter that still has incomplete goals
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
 
           {/* To row */}
@@ -347,10 +360,7 @@ export function PullGoalsPreviewDialog(props: PullGoalsPreviewDialogProps) {
             </div>
           ) : (
             <div
-              className={cn(
-                'space-y-6',
-                isRefreshingPreview && 'opacity-50 transition-opacity'
-              )}
+              className={cn('space-y-6', isRefreshingPreview && 'opacity-50 transition-opacity')}
             >
               {/* Section A: Week pull */}
               {fromWeek && (

--- a/apps/webapp/src/components/ui/alert-dialog.tsx
+++ b/apps/webapp/src/components/ui/alert-dialog.tsx
@@ -49,8 +49,12 @@ function AlertDialogOverlay({
 
 function AlertDialogContent({
   className,
+  onOverlayClick,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  /** Optional: dismiss when the dimmed overlay is clicked (AlertDialog does not do this by default). */
+  onOverlayClick?: React.MouseEventHandler<HTMLDivElement>;
+}) {
   // Fix iOS text selection handles not being draggable
   // Must be called before react-remove-scroll attaches its listeners
   // https://github.com/theKashey/react-remove-scroll/pull/144
@@ -58,7 +62,7 @@ function AlertDialogContent({
 
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay onClick={onOverlayClick} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(


### PR DESCRIPTION
## Summary
- Adds a tooltip on the Pull Goals **Jump** button explaining it sets From to the last earlier week in the current quarter with incomplete goals.
- Allows dismissing the Pull Goals dialog by clicking the dimmed overlay (outside the modal).
- **Decision on `modal`:** Kept `AlertDialog` and did **not** change any `modal` prop. Radix AlertDialog never closes on outside click by design; instead we added an opt-in `onOverlayClick` on `AlertDialogContent` (overlay sibling click → `onOpenChange(false)`). Other alert dialogs stay non-dismissible unless they opt in.

## Test plan
- [ ] Open Pull Goals → hover Jump → tooltip describes same-quarter last non-empty week
- [ ] Click dimmed area outside the dialog → dialog closes
- [ ] Click Cancel / Escape still work
- [ ] Other AlertDialogs (e.g. destructive confirms) still do **not** dismiss on outside click
- [ ] `pnpm test` in webapp for PullGoalsPreviewDialog tests

Made with [Cursor](https://cursor.com)