### PR TITLE
fix(initiatives): Safari initiative selector search not clickable

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeSelector.test.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { InitiativeSelector } from './InitiativeSelector';
+
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const initiatives = [
+  {
+    _id: 'initiatives:alpha' as Id<'initiatives'>,
+    _creationTime: 0,
+    userId: 'users:test' as Id<'users'>,
+    title: 'Q1 Launch',
+    startDate: 1_700_000_000_000,
+    description: undefined,
+    endDate: undefined,
+  },
+] as Doc<'initiatives'>[];
+
+describe('InitiativeSelector', () => {
+  it('allows focusing the search input when the combobox is open', () => {
+    render(
+      <InitiativeSelector
+        initiatives={initiatives}
+        selectedInitiativeId={null}
+        onInitiativeChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const search = screen.getByPlaceholderText('Search initiatives...');
+    expect(search).toBeInTheDocument();
+
+    search.focus();
+    expect(document.activeElement).toBe(search);
+  });
+
+  it('keeps combobox content in the same DOM tree as the trigger (unportalled)', () => {
+    const { container } = render(
+      <div data-testid="host">
+        <InitiativeSelector
+          initiatives={initiatives}
+          selectedInitiativeId={null}
+          onInitiativeChange={vi.fn()}
+        />
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const host = screen.getByTestId('host');
+    const search = screen.getByPlaceholderText('Search initiatives...');
+    // Unportalled content must remain under the host (not only under document.body via Portal)
+    expect(host.contains(search)).toBe(true);
+    expect(container.contains(search)).toBe(true);
+  });
+});

--- a/apps/webapp/src/components/atoms/InitiativeSelector.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.tsx
@@ -75,7 +75,16 @@ export function InitiativeSelector({
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        {/*
+          portalled={false}: keep combobox in the dialog DOM tree so Safari can
+          focus/click the search input (Radix portal + dialog focus trap blocks it).
+          modal on Popover (above) still required so the list opens inside dialogs.
+        */}
+        <PopoverContent
+          portalled={false}
+          className="w-[--radix-popover-trigger-width] p-0"
+          align="start"
+        >
           <Command>
             <CommandInput placeholder="Search initiatives..." />
             <CommandList>

--- a/apps/webapp/src/components/ui/popover.tsx
+++ b/apps/webapp/src/components/ui/popover.tsx
@@ -25,22 +25,33 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  /**
+   * When false, content is not portalled. Use inside Dialog/AlertDialog so Safari
+   * can focus nested inputs (e.g. combobox search). Default keeps portal behavior.
+   */
+  portalled = true,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
-  return (
-    <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'bg-popover/95 backdrop-blur-sm text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) border-2 border-border/20 p-4 shadow-md outline-hidden',
-          className
-        )}
-        {...props}
-      />
-    </PopoverPrimitive.Portal>
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  portalled?: boolean;
+}) {
+  const content = (
+    <PopoverPrimitive.Content
+      data-slot="popover-content"
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'bg-popover/95 backdrop-blur-sm text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) border-2 border-border/20 p-4 shadow-md outline-hidden',
+        className
+      )}
+      {...props}
+    />
   );
+
+  if (!portalled) {
+    return content;
+  }
+
+  return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>;
 }
 
 function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {


### PR DESCRIPTION
## Summary
- Fixes Safari bug where the initiative selector **search input** is not clickable/focusable inside goal dialogs.
- Root cause: portalled Popover content sits outside the Dialog DOM; Safari’s dialog focus trap blocks focusing nested portal inputs ([radix#3132](https://github.com/radix-ui/primitives/issues/3132) / shadcn combobox-in-dialog).
- Keeps `Popover modal` from #78 (needed so the list opens) and sets `portalled={false}` on this combobox only via a new optional `PopoverContent` prop (other popovers stay portalled).

## Test plan
- [ ] In Safari, open a goal details dialog and click the initiative combobox
- [ ] Click the “Search initiatives...” field — caret should appear and typing should filter
- [ ] Select an initiative — selection persists
- [ ] Chrome/Firefox unchanged
- [ ] Other Popovers (DatePicker, menus) still portal correctly
- [ ] `pnpm exec vitest run src/components/atoms/InitiativeSelector.test.tsx`

Made with [Cursor](https://cursor.com)