### PR TITLE
feat(dashboard): migrate view-mode to path routes

### DIFF
--- a/apps/webapp/src/app/app/[viewMode]/page.tsx
+++ b/apps/webapp/src/app/app/[viewMode]/page.tsx
@@ -8,12 +8,6 @@ import { isViewMode } from '@/lib/dashboard/dashboardUrlParams';
 
 const DashboardViewPage = () => {
   const params = useParams();
-  const viewModeParam = params.viewMode as string;
-
-  if (!isViewMode(viewModeParam)) {
-    notFound();
-  }
-
   const {
     selectedWeek,
     selectedDayOfWeek,
@@ -23,6 +17,11 @@ const DashboardViewPage = () => {
     handlePrevious,
     handleNext,
   } = useDashboard();
+
+  const viewModeParam = params.viewMode;
+  if (typeof viewModeParam !== 'string' || !isViewMode(viewModeParam)) {
+    notFound();
+  }
 
   return (
     <div className="flex flex-col h-full overflow-hidden">

--- a/apps/webapp/src/app/app/[viewMode]/page.tsx
+++ b/apps/webapp/src/app/app/[viewMode]/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { notFound, useParams } from 'next/navigation';
+
+import { DashboardFocusView } from '@/components/organisms/DashboardFocusView';
+import { useDashboard } from '@/hooks/useDashboard';
+import { isViewMode } from '@/lib/dashboard/dashboardUrlParams';
+
+const DashboardViewPage = () => {
+  const params = useParams();
+  const viewModeParam = params.viewMode as string;
+
+  if (!isViewMode(viewModeParam)) {
+    notFound();
+  }
+
+  const {
+    selectedWeek,
+    selectedDayOfWeek,
+    viewMode,
+    handleViewModeChange,
+    handleYearQuarterChange,
+    handlePrevious,
+    handleNext,
+  } = useDashboard();
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="flex-1 min-h-0 overflow-auto">
+        <DashboardFocusView
+          viewMode={viewMode}
+          selectedWeekNumber={selectedWeek}
+          selectedDayOfWeek={selectedDayOfWeek}
+          onViewModeChange={handleViewModeChange}
+          onPrevious={handlePrevious}
+          onNext={handleNext}
+          onYearQuarterChange={handleYearQuarterChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DashboardViewPage;

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -1,37 +1,31 @@
 'use client';
 
-import { DashboardFocusView } from '@/components/organisms/DashboardFocusView';
-import { useDashboard } from '@/hooks/useDashboard';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
-/**
- * Main dashboard page displaying goals in quarterly, weekly, or daily views.
- */
-const DashboardPage = () => {
-  const {
-    selectedWeek,
-    selectedDayOfWeek,
-    viewMode,
-    handleViewModeChange,
-    handleYearQuarterChange,
-    handlePrevious,
-    handleNext,
-  } = useDashboard();
+import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
+import {
+  buildDashboardViewHref,
+  getLegacyViewModeRedirectHref,
+} from '@/lib/dashboard/dashboardUrlParams';
 
-  return (
-    <div className="flex flex-col h-full overflow-hidden">
-      <div className="flex-1 min-h-0 overflow-auto">
-        <DashboardFocusView
-          viewMode={viewMode}
-          selectedWeekNumber={selectedWeek}
-          selectedDayOfWeek={selectedDayOfWeek}
-          onViewModeChange={handleViewModeChange}
-          onPrevious={handlePrevious}
-          onNext={handleNext}
-          onYearQuarterChange={handleYearQuarterChange}
-        />
-      </div>
-    </div>
-  );
+const DashboardRedirectPage = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isMobile } = useDeviceScreenInfo();
+
+  useEffect(() => {
+    const legacy = getLegacyViewModeRedirectHref(searchParams);
+    if (legacy) {
+      router.replace(legacy);
+      return;
+    }
+
+    const defaultViewMode = isMobile ? 'focused' : 'quarterly';
+    router.replace(buildDashboardViewHref(defaultViewMode));
+  }, [router, searchParams, isMobile]);
+
+  return null;
 };
 
-export default DashboardPage;
+export default DashboardRedirectPage;

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalDetailsPageShell.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalDetailsPageShell.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { ArrowLeft, Calendar, Home, Loader2, Target } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useCallback, type ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+function useGoalPageNavigation(dashboardHref: string) {
+  const router = useRouter();
+
+  const handleGoBack = useCallback(() => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/app');
+    }
+  }, [router]);
+
+  const handleGoHome = useCallback(() => {
+    router.push('/app');
+  }, [router]);
+
+  const handleGoToDashboard = useCallback(() => {
+    router.push(dashboardHref);
+  }, [router, dashboardHref]);
+
+  return { handleGoBack, handleGoHome, handleGoToDashboard };
+}
+
+interface GoalDetailsPageShellProps {
+  goalTitle: string;
+  hasGoalDetails: boolean;
+  contextBadgeLabel: string;
+  isLoading: boolean;
+  isNotFound: boolean;
+  notFoundDescription: string;
+  dashboardHref: string;
+  children: ReactNode;
+}
+
+/**
+ * Shared shell for full-page goal detail views (header, loading, not-found).
+ */
+export function GoalDetailsPageShell({
+  goalTitle,
+  hasGoalDetails,
+  contextBadgeLabel,
+  isLoading,
+  isNotFound,
+  notFoundDescription,
+  dashboardHref,
+  children,
+}: GoalDetailsPageShellProps) {
+  const { handleGoBack, handleGoHome, handleGoToDashboard } = useGoalPageNavigation(dashboardHref);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="bg-card border-b sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-14 sm:h-16">
+            <div className="flex items-center space-x-2 sm:space-x-4 min-w-0">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleGoBack}
+                className="flex items-center gap-1.5 flex-shrink-0"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                <span className="hidden sm:inline">Back</span>
+              </Button>
+
+              <div className="flex items-center space-x-2 text-sm text-muted-foreground min-w-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleGoHome}
+                  className="flex items-center gap-1 h-8 px-2 flex-shrink-0"
+                >
+                  <Home className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">Dashboard</span>
+                </Button>
+                <span className="hidden sm:inline">/</span>
+                <span className="hidden sm:inline">Goal</span>
+                {hasGoalDetails && (
+                  <>
+                    <span className="hidden sm:inline">/</span>
+                    <span className="font-medium text-foreground truncate max-w-[120px] sm:max-w-xs">
+                      {goalTitle}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleGoToDashboard}
+                className="flex items-center gap-1.5 text-xs"
+              >
+                <Calendar className="h-3.5 w-3.5" />
+                <span>{contextBadgeLabel}</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-16">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
+            <p className="text-muted-foreground">Loading goal details...</p>
+          </div>
+        )}
+
+        {isNotFound && (
+          <div className="flex flex-col items-center justify-center py-16">
+            <Target className="h-12 w-12 text-muted-foreground/50 mb-4" />
+            <h2 className="text-xl font-semibold text-foreground mb-2">Goal not found</h2>
+            <p className="text-muted-foreground mb-6">{notFoundDescription}</p>
+            <Button onClick={handleGoHome}>
+              <Home className="h-4 w-4 mr-2" />
+              Return to Dashboard
+            </Button>
+          </div>
+        )}
+
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalPageContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalPageContent.tsx
@@ -13,17 +13,16 @@ import { api } from '@workspace/backend/convex/_generated/api';
 import type { Id } from '@workspace/backend/convex/_generated/dataModel';
 import type { GoalWithDetailsAndChildren } from '@workspace/backend/src/usecase/getWeekDetails';
 import { useQuery } from 'convex/react';
-import { ArrowLeft, Calendar, Home, Loader2, Target } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { AdhocGoalPopoverContent } from './AdhocGoalPopoverContent';
+import { GoalDetailsPageShell } from './GoalDetailsPageShell';
 import { StandardGoalPopoverContent } from './StandardGoalPopoverContent';
 import { WeeklyGoalPageContent } from './WeeklyGoalPageContent';
 
-import { Button } from '@/components/ui/button';
 import { GoalProvider } from '@/contexts/GoalContext';
 import { WeekProvider } from '@/hooks/useWeek';
+import { buildDashboardHref } from '@/lib/dashboard/dashboardUrlParams';
 import { cn } from '@/lib/utils';
 import { useSession } from '@/modules/auth/useSession';
 
@@ -84,176 +83,80 @@ export function GoalPageContent({
   quarter: quarterProp,
 }: GoalPageContentProps) {
   const { sessionId } = useSession();
-  const router = useRouter();
 
   const quarter = useMemo(() => {
     if (quarterProp !== undefined) return quarterProp;
     return getQuarterFromWeek(weekNumber);
   }, [quarterProp, weekNumber]);
 
-  // Fetch week data for context
   const weekData = useQuery(
     api.dashboard.getWeek,
     sessionId ? { sessionId, year, quarter, weekNumber } : 'skip'
   );
 
-  // Fetch goal details
   const goalDetails = useQuery(
     api.dashboard.getGoalDetails,
     goalId && sessionId ? { sessionId, goalId } : 'skip'
   );
 
-  const handleGoBack = useCallback(() => {
-    if (window.history.length > 1) {
-      router.back();
-    } else {
-      router.push('/app');
-    }
-  }, [router]);
-
-  const handleGoHome = useCallback(() => {
-    router.push('/app');
-  }, [router]);
-
-  const handleGoToDashboard = useCallback(() => {
-    const params = new URLSearchParams();
-    params.set('year', year.toString());
-    params.set('week', weekNumber.toString());
-    router.push(`/app/weekly?${params.toString()}`);
-  }, [router, year, weekNumber]);
-
   const goalType = goalDetails
     ? getGoalType(goalDetails as unknown as GoalWithDetailsAndChildren)
     : null;
   const goalTitle = goalDetails?.title ?? 'Loading...';
+  const dashboardHref = buildDashboardHref('weekly', new URLSearchParams(), {
+    year,
+    week: weekNumber,
+  });
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="bg-card border-b sticky top-0 z-10">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14 sm:h-16">
-            {/* Breadcrumb Navigation */}
-            <div className="flex items-center space-x-2 sm:space-x-4 min-w-0">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleGoBack}
-                className="flex items-center gap-1.5 flex-shrink-0"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                <span className="hidden sm:inline">Back</span>
-              </Button>
-
-              <div className="flex items-center space-x-2 text-sm text-muted-foreground min-w-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleGoHome}
-                  className="flex items-center gap-1 h-8 px-2 flex-shrink-0"
-                >
-                  <Home className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Dashboard</span>
-                </Button>
-                <span className="hidden sm:inline">/</span>
-                <span className="hidden sm:inline">Goal</span>
-                {goalDetails && (
-                  <>
-                    <span className="hidden sm:inline">/</span>
-                    <span className="font-medium text-foreground truncate max-w-[120px] sm:max-w-xs">
-                      {goalTitle}
-                    </span>
-                  </>
+    <GoalDetailsPageShell
+      goalTitle={goalTitle}
+      hasGoalDetails={Boolean(goalDetails)}
+      contextBadgeLabel={`W${weekNumber} · Q${quarter} ${year}`}
+      isLoading={weekData === undefined || goalDetails === undefined}
+      isNotFound={goalDetails === null}
+      notFoundDescription="This goal may have been deleted or you don't have access to it."
+      dashboardHref={dashboardHref}
+    >
+      {weekData && goalDetails && goalType && (
+        <div className="bg-card rounded-lg border shadow-sm">
+          <div className="p-4 sm:p-6 lg:p-8">
+            <div className="mb-4">
+              <span
+                className={cn(
+                  'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
+                  goalType === 'quarterly' &&
+                    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+                  goalType === 'weekly' &&
+                    'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+                  goalType === 'daily' &&
+                    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+                  goalType === 'adhoc' &&
+                    'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
                 )}
-              </div>
+              >
+                {goalType === 'quarterly' && 'Quarterly Goal'}
+                {goalType === 'weekly' && 'Weekly Goal'}
+                {goalType === 'daily' && 'Daily Goal'}
+                {goalType === 'adhoc' && 'Adhoc Task'}
+              </span>
             </div>
 
-            {/* Context Badge */}
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleGoToDashboard}
-                className="flex items-center gap-1.5 text-xs"
-              >
-                <Calendar className="h-3.5 w-3.5" />
-                <span>
-                  W{weekNumber} · Q{quarter} {year}
-                </span>
-              </Button>
-            </div>
+            <WeekProvider weekData={{ ...weekData, year, quarter }}>
+              <GoalProvider goal={goalDetails as unknown as GoalWithDetailsAndChildren}>
+                {goalType === 'quarterly' && <StandardGoalPopoverContent />}
+                {goalType === 'weekly' && <WeeklyGoalPageContent />}
+                {goalType === 'adhoc' && <AdhocGoalPopoverContent weekNumber={weekNumber} />}
+                {goalType === 'daily' && (
+                  <div className="text-muted-foreground text-center py-8">
+                    Daily goal view coming soon
+                  </div>
+                )}
+              </GoalProvider>
+            </WeekProvider>
           </div>
         </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-        {/* Loading State */}
-        {(weekData === undefined || goalDetails === undefined) && (
-          <div className="flex flex-col items-center justify-center py-16">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
-            <p className="text-muted-foreground">Loading goal details...</p>
-          </div>
-        )}
-
-        {/* Not Found State */}
-        {goalDetails === null && (
-          <div className="flex flex-col items-center justify-center py-16">
-            <Target className="h-12 w-12 text-muted-foreground/50 mb-4" />
-            <h2 className="text-xl font-semibold text-foreground mb-2">Goal not found</h2>
-            <p className="text-muted-foreground mb-6">
-              This goal may have been deleted or you don't have access to it.
-            </p>
-            <Button onClick={handleGoHome}>
-              <Home className="h-4 w-4 mr-2" />
-              Return to Dashboard
-            </Button>
-          </div>
-        )}
-
-        {/* Goal Content */}
-        {weekData && goalDetails && goalType && (
-          <div className="bg-card rounded-lg border shadow-sm">
-            <div className="p-4 sm:p-6 lg:p-8">
-              {/* Goal Type Badge */}
-              <div className="mb-4">
-                <span
-                  className={cn(
-                    'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
-                    goalType === 'quarterly' &&
-                      'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
-                    goalType === 'weekly' &&
-                      'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-                    goalType === 'daily' &&
-                      'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-                    goalType === 'adhoc' &&
-                      'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300'
-                  )}
-                >
-                  {goalType === 'quarterly' && 'Quarterly Goal'}
-                  {goalType === 'weekly' && 'Weekly Goal'}
-                  {goalType === 'daily' && 'Daily Goal'}
-                  {goalType === 'adhoc' && 'Adhoc Task'}
-                </span>
-              </div>
-
-              {/* Goal Content based on type */}
-              <WeekProvider weekData={{ ...weekData, year, quarter }}>
-                <GoalProvider goal={goalDetails as unknown as GoalWithDetailsAndChildren}>
-                  {goalType === 'quarterly' && <StandardGoalPopoverContent />}
-                  {goalType === 'weekly' && <WeeklyGoalPageContent />}
-                  {goalType === 'adhoc' && <AdhocGoalPopoverContent weekNumber={weekNumber} />}
-                  {goalType === 'daily' && (
-                    <div className="text-muted-foreground text-center py-8">
-                      Daily goal view coming soon
-                    </div>
-                  )}
-                </GoalProvider>
-              </WeekProvider>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
+      )}
+    </GoalDetailsPageShell>
   );
 }

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalPageContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/GoalPageContent.tsx
@@ -118,11 +118,9 @@ export function GoalPageContent({
   const handleGoToDashboard = useCallback(() => {
     const params = new URLSearchParams();
     params.set('year', year.toString());
-    params.set('quarter', quarter.toString());
     params.set('week', weekNumber.toString());
-    params.set('viewMode', 'weekly');
-    router.push(`/app?${params.toString()}`);
-  }, [router, year, quarter, weekNumber]);
+    router.push(`/app/weekly?${params.toString()}`);
+  }, [router, year, weekNumber]);
 
   const goalType = goalDetails
     ? getGoalType(goalDetails as unknown as GoalWithDetailsAndChildren)

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPullPreviewContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPullPreviewContent.tsx
@@ -105,8 +105,7 @@ export function QuarterlyGoalPullPreviewContent({
     const params = new URLSearchParams();
     params.set('year', year.toString());
     params.set('quarter', quarter.toString());
-    params.set('viewMode', 'quarterly');
-    router.push(`/app?${params.toString()}`);
+    router.push(`/app/quarterly?${params.toString()}`);
   }, [router, year, quarter]);
 
   const goalTitle = goalDetails?.title ?? 'Loading...';

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPullPreviewContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPullPreviewContent.tsx
@@ -12,15 +12,14 @@ import type { Id } from '@workspace/backend/convex/_generated/dataModel';
 import type { GoalWithDetailsAndChildren } from '@workspace/backend/src/usecase/getWeekDetails';
 import { getQuarterWeeks } from '@workspace/backend/src/usecase/quarter';
 import { useSessionQuery } from 'convex-helpers/react/sessions';
-import { ArrowLeft, Calendar, Home, Loader2, Target } from 'lucide-react';
-import { useRouter } from 'next/navigation';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
+import { GoalDetailsPageShell } from './GoalDetailsPageShell';
 import { StandardGoalPopoverContent } from './StandardGoalPopoverContent';
 
-import { Button } from '@/components/ui/button';
 import { GoalProvider } from '@/contexts/GoalContext';
 import { WeekProvider } from '@/hooks/useWeek';
+import { buildDashboardHref } from '@/lib/dashboard/dashboardUrlParams';
 import { cn } from '@/lib/utils';
 
 /**
@@ -50,34 +49,27 @@ export function QuarterlyGoalPullPreviewContent({
   year,
   quarter,
 }: QuarterlyGoalPullPreviewContentProps) {
-  const router = useRouter();
-
-  // Fetch goal details with year and quarter context
   const goalDetails = useSessionQuery(
     api.goal.getGoalPullPreviewDetails,
     goalId ? { goalId, year, quarter } : 'skip'
   );
 
-  // Get the last non-empty week from the backend response
   const lastNonEmptyWeek = useMemo(() => {
     if (goalDetails?.lastNonEmptyWeek) {
       return goalDetails.lastNonEmptyWeek;
     }
-    // Fallback to the last week of the quarter if not provided
     const { endWeek } = getQuarterWeeks(year, quarter);
     return endWeek;
   }, [goalDetails, year, quarter]);
 
-  // Create mock week data for the WeekProvider
-  // We use the last non-empty week as context
   const mockWeekData = useMemo(() => {
     return {
       weekLabel: `W${lastNonEmptyWeek}`,
       weekNumber: lastNonEmptyWeek,
-      mondayDate: '', // Not used in read-only preview
+      mondayDate: '',
       year,
       quarter,
-      days: [], // Not used in read-only preview
+      days: [],
       tree: {
         weekNumber: lastNonEmptyWeek,
         allGoals: [],
@@ -89,146 +81,52 @@ export function QuarterlyGoalPullPreviewContent({
     };
   }, [lastNonEmptyWeek, year, quarter]);
 
-  const handleGoBack = useCallback(() => {
-    if (window.history.length > 1) {
-      router.back();
-    } else {
-      router.push('/app');
-    }
-  }, [router]);
-
-  const handleGoHome = useCallback(() => {
-    router.push('/app');
-  }, [router]);
-
-  const handleGoToDashboard = useCallback(() => {
-    const params = new URLSearchParams();
-    params.set('year', year.toString());
-    params.set('quarter', quarter.toString());
-    router.push(`/app/quarterly?${params.toString()}`);
-  }, [router, year, quarter]);
-
   const goalTitle = goalDetails?.title ?? 'Loading...';
+  const dashboardHref = buildDashboardHref('quarterly', new URLSearchParams(), {
+    year,
+    quarter,
+  });
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="bg-card border-b sticky top-0 z-10">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-14 sm:h-16">
-            {/* Breadcrumb Navigation */}
-            <div className="flex items-center space-x-2 sm:space-x-4 min-w-0">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleGoBack}
-                className="flex items-center gap-1.5 flex-shrink-0"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                <span className="hidden sm:inline">Back</span>
-              </Button>
-
-              <div className="flex items-center space-x-2 text-sm text-muted-foreground min-w-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleGoHome}
-                  className="flex items-center gap-1 h-8 px-2 flex-shrink-0"
-                >
-                  <Home className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">Dashboard</span>
-                </Button>
-                <span className="hidden sm:inline">/</span>
-                <span className="hidden sm:inline">Goal</span>
-                {goalDetails && (
-                  <>
-                    <span className="hidden sm:inline">/</span>
-                    <span className="font-medium text-foreground truncate max-w-[120px] sm:max-w-xs">
-                      {goalTitle}
-                    </span>
-                  </>
+    <GoalDetailsPageShell
+      goalTitle={goalTitle}
+      hasGoalDetails={Boolean(goalDetails)}
+      contextBadgeLabel={`Q${quarter} ${year}`}
+      isLoading={goalDetails === undefined}
+      isNotFound={goalDetails === null}
+      notFoundDescription="This goal may have been deleted, doesn't belong to the specified quarter, or you don't have access to it."
+      dashboardHref={dashboardHref}
+    >
+      {goalDetails && (
+        <div className="bg-card rounded-lg border shadow-sm">
+          <div className="p-4 sm:p-6 lg:p-8">
+            <div className="mb-4 flex items-center gap-3 flex-wrap">
+              <span
+                className={cn(
+                  'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
+                  'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
                 )}
-              </div>
+              >
+                Quarterly Goal (Last Week Preview)
+              </span>
+              <span
+                className={cn(
+                  'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
+                  'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
+                )}
+              >
+                Week {lastNonEmptyWeek}
+              </span>
             </div>
 
-            {/* Context Badge */}
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleGoToDashboard}
-                className="flex items-center gap-1.5 text-xs"
-              >
-                <Calendar className="h-3.5 w-3.5" />
-                <span>
-                  Q{quarter} {year}
-                </span>
-              </Button>
-            </div>
+            <WeekProvider weekData={mockWeekData}>
+              <GoalProvider goal={goalDetails as unknown as GoalWithDetailsAndChildren}>
+                <StandardGoalPopoverContent />
+              </GoalProvider>
+            </WeekProvider>
           </div>
         </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-        {/* Loading State */}
-        {goalDetails === undefined && (
-          <div className="flex flex-col items-center justify-center py-16">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-4" />
-            <p className="text-muted-foreground">Loading goal details...</p>
-          </div>
-        )}
-
-        {/* Not Found State */}
-        {goalDetails === null && (
-          <div className="flex flex-col items-center justify-center py-16">
-            <Target className="h-12 w-12 text-muted-foreground/50 mb-4" />
-            <h2 className="text-xl font-semibold text-foreground mb-2">Goal not found</h2>
-            <p className="text-muted-foreground mb-6">
-              This goal may have been deleted, doesn't belong to the specified quarter, or you don't
-              have access to it.
-            </p>
-            <Button onClick={handleGoHome}>
-              <Home className="h-4 w-4 mr-2" />
-              Return to Dashboard
-            </Button>
-          </div>
-        )}
-
-        {/* Goal Content */}
-        {goalDetails && (
-          <div className="bg-card rounded-lg border shadow-sm">
-            <div className="p-4 sm:p-6 lg:p-8">
-              {/* Goal Type Badge and Week Info */}
-              <div className="mb-4 flex items-center gap-3 flex-wrap">
-                <span
-                  className={cn(
-                    'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
-                    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
-                  )}
-                >
-                  Quarterly Goal (Last Week Preview)
-                </span>
-                <span
-                  className={cn(
-                    'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
-                    'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300'
-                  )}
-                >
-                  Week {lastNonEmptyWeek}
-                </span>
-              </div>
-
-              {/* Goal Content */}
-              <WeekProvider weekData={mockWeekData}>
-                <GoalProvider goal={goalDetails as unknown as GoalWithDetailsAndChildren}>
-                  <StandardGoalPopoverContent />
-                </GoalProvider>
-              </WeekProvider>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
+      )}
+    </GoalDetailsPageShell>
   );
 }

--- a/apps/webapp/src/hooks/useDashboard.tsx
+++ b/apps/webapp/src/hooks/useDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type React from 'react';
 import { createContext, useCallback, useContext, useMemo } from 'react';
 
@@ -11,9 +11,9 @@ import type { ViewMode } from '@/components/molecules/focus/constants';
 import { useDeviceScreenInfo } from '@/hooks/useDeviceScreenInfo';
 import { DayOfWeek } from '@/lib/constants';
 import {
-  applyDashboardUrlUpdates,
-  buildUrlParamsForViewModeChange,
-  parseViewMode,
+  buildDashboardHref,
+  buildDashboardViewHref,
+  getViewModeFromPathname,
   type DashboardUrlUpdates,
 } from '@/lib/dashboard/dashboardUrlParams';
 import { getWeeksInYear } from '@/lib/date/iso-week';
@@ -72,6 +72,7 @@ const DashboardContext = createContext<DashboardContextValue | 'not-found'>('not
 export const DashboardProvider = ({ children }: { children: React.ReactNode }) => {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const pathname = usePathname();
   const { isMobile } = useDeviceScreenInfo();
 
   // Use reactive current date - already optimized to update daily
@@ -101,9 +102,10 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
     selectedQuarter
   );
 
-  // Get view mode from URL or use default based on screen size
+  // Get view mode from pathname or use default based on screen size
   const defaultViewMode: ViewMode = isMobile ? 'focused' : 'quarterly';
-  const viewMode = parseViewMode(searchParams.get('view-mode'), defaultViewMode);
+  const pathViewMode = getViewModeFromPathname(pathname);
+  const viewMode = pathViewMode ?? defaultViewMode;
 
   // Get selected week from URL or use current week
   const weekFromUrl = searchParams.get('week');
@@ -130,40 +132,29 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
         ? false // No bounds in daily view - can navigate freely
         : false; // No bounds in weekly view - can navigate freely
 
-  const navigationDefaults = useMemo(
-    () => ({
-      year: currentYear,
-      quarter: currentQuarter,
-      week: currentWeekNumber,
-      day: currentDate.weekday as DayOfWeek,
-    }),
-    [currentYear, currentQuarter, currentWeekNumber, currentDate.weekday]
-  );
-
   // Update URL helper function
   const updateUrlParams = useCallback(
     (params: DashboardUrlUpdates) => {
-      const newParams = applyDashboardUrlUpdates(searchParams, params);
-      router.replace(`/app?${newParams.toString()}`, { scroll: false });
+      const href = buildDashboardHref(viewMode, searchParams, params);
+      router.replace(href, { scroll: false });
     },
-    [router, searchParams]
+    [router, searchParams, viewMode]
   );
 
   // Handle view mode changes
   const handleViewModeChange = useCallback(
     (newViewMode: ViewMode) => {
       if (newViewMode === viewMode) {
+        if (pathViewMode != null && searchParams.toString() === '') {
+          return;
+        }
+        router.replace(buildDashboardViewHref(newViewMode), { scroll: false });
         return;
       }
 
-      const newParams = buildUrlParamsForViewModeChange(
-        searchParams,
-        newViewMode,
-        navigationDefaults
-      );
-      router.replace(`/app?${newParams.toString()}`, { scroll: false });
+      router.replace(buildDashboardViewHref(newViewMode), { scroll: false });
     },
-    [navigationDefaults, router, searchParams, viewMode]
+    [router, searchParams, viewMode, pathViewMode]
   );
 
   // Handle year and quarter changes

--- a/apps/webapp/src/hooks/useDashboard.tsx
+++ b/apps/webapp/src/hooks/useDashboard.tsx
@@ -141,14 +141,10 @@ export const DashboardProvider = ({ children }: { children: React.ReactNode }) =
     [router, searchParams, viewMode]
   );
 
-  // Handle view mode changes
+  // Handle view mode changes — always land on a clean path (no query string)
   const handleViewModeChange = useCallback(
     (newViewMode: ViewMode) => {
-      if (newViewMode === viewMode) {
-        if (pathViewMode != null && searchParams.toString() === '') {
-          return;
-        }
-        router.replace(buildDashboardViewHref(newViewMode), { scroll: false });
+      if (newViewMode === viewMode && pathViewMode != null && searchParams.toString() === '') {
         return;
       }
 

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  applyDashboardUrlUpdates,
   buildDashboardHref,
   buildDashboardViewHref,
   getLegacyViewModeRedirectHref,
   getViewModeFromPathname,
   isViewMode,
-  parseViewMode,
 } from './dashboardUrlParams';
 
 import { DayOfWeek } from '@/lib/constants';
@@ -23,18 +21,6 @@ describe('isViewMode', () => {
   it('returns false for invalid values', () => {
     expect(isViewMode('invalid')).toBe(false);
     expect(isViewMode('')).toBe(false);
-  });
-});
-
-describe('parseViewMode', () => {
-  it('returns valid view modes from the URL', () => {
-    expect(parseViewMode('focused', 'quarterly')).toBe('focused');
-  });
-
-  it('falls back for invalid values', () => {
-    expect(parseViewMode('invalid', 'quarterly')).toBe('quarterly');
-    expect(parseViewMode(null, 'daily')).toBe('daily');
-    expect(parseViewMode(undefined, 'weekly')).toBe('weekly');
   });
 });
 
@@ -108,6 +94,14 @@ describe('buildDashboardHref', () => {
     expect(href).toBe('/app/daily?year=2026&week=24&day=3');
     expect(href).not.toContain('view-mode');
   });
+
+  it('strips legacy view-mode when applying empty updates', () => {
+    const current = new URLSearchParams('view-mode=weekly&week=10&year=2026');
+    const href = buildDashboardHref('weekly', current, {});
+
+    expect(href).toBe('/app/weekly?week=10&year=2026');
+    expect(href).not.toContain('view-mode');
+  });
 });
 
 describe('getLegacyViewModeRedirectHref', () => {
@@ -139,23 +133,5 @@ describe('getLegacyViewModeRedirectHref', () => {
   it('returns null for invalid view-mode', () => {
     const params = new URLSearchParams('view-mode=invalid');
     expect(getLegacyViewModeRedirectHref(params)).toBeNull();
-  });
-});
-
-describe('applyDashboardUrlUpdates', () => {
-  it('merges partial updates onto existing params without view-mode', () => {
-    const current = new URLSearchParams('week=10&year=2026');
-    const next = applyDashboardUrlUpdates(current, { week: 11 });
-
-    expect(next.get('week')).toBe('11');
-    expect(next.has('view-mode')).toBe(false);
-  });
-
-  it('strips view-mode from existing params', () => {
-    const current = new URLSearchParams('view-mode=weekly&week=10&year=2026');
-    const next = applyDashboardUrlUpdates(current, { week: 11 });
-
-    expect(next.get('week')).toBe('11');
-    expect(next.has('view-mode')).toBe(false);
   });
 });

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.test.ts
@@ -2,18 +2,29 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyDashboardUrlUpdates,
-  buildUrlParamsForViewModeChange,
+  buildDashboardHref,
+  buildDashboardViewHref,
+  getLegacyViewModeRedirectHref,
+  getViewModeFromPathname,
+  isViewMode,
   parseViewMode,
 } from './dashboardUrlParams';
 
 import { DayOfWeek } from '@/lib/constants';
 
-const defaults = {
-  year: 2026,
-  quarter: 2 as const,
-  week: 24,
-  day: DayOfWeek.WEDNESDAY,
-};
+describe('isViewMode', () => {
+  it('returns true for valid view modes', () => {
+    expect(isViewMode('daily')).toBe(true);
+    expect(isViewMode('weekly')).toBe(true);
+    expect(isViewMode('quarterly')).toBe(true);
+    expect(isViewMode('focused')).toBe(true);
+  });
+
+  it('returns false for invalid values', () => {
+    expect(isViewMode('invalid')).toBe(false);
+    expect(isViewMode('')).toBe(false);
+  });
+});
 
 describe('parseViewMode', () => {
   it('returns valid view modes from the URL', () => {
@@ -23,65 +34,128 @@ describe('parseViewMode', () => {
   it('falls back for invalid values', () => {
     expect(parseViewMode('invalid', 'quarterly')).toBe('quarterly');
     expect(parseViewMode(null, 'daily')).toBe('daily');
+    expect(parseViewMode(undefined, 'weekly')).toBe('weekly');
   });
 });
 
-describe('buildUrlParamsForViewModeChange', () => {
-  it('drops stale week/day/quarter params when switching to focused', () => {
-    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
-
-    const next = buildUrlParamsForViewModeChange(current, 'focused', defaults);
-
-    expect(next.get('view-mode')).toBe('focused');
-    expect(next.get('year')).toBe('2026');
-    expect(next.has('week')).toBe(false);
-    expect(next.has('day')).toBe(false);
-    expect(next.has('quarter')).toBe(false);
+describe('getViewModeFromPathname', () => {
+  it('extracts view mode from pathname', () => {
+    expect(getViewModeFromPathname('/app/quarterly')).toBe('quarterly');
+    expect(getViewModeFromPathname('/app/weekly')).toBe('weekly');
+    expect(getViewModeFromPathname('/app/daily')).toBe('daily');
+    expect(getViewModeFromPathname('/app/focused')).toBe('focused');
   });
 
-  it('keeps only quarterly params when switching to quarterly', () => {
-    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
-
-    const next = buildUrlParamsForViewModeChange(current, 'quarterly', defaults);
-
-    expect(next.get('view-mode')).toBe('quarterly');
-    expect(next.get('year')).toBe('2026');
-    expect(next.get('quarter')).toBe('1');
-    expect(next.has('week')).toBe(false);
-    expect(next.has('day')).toBe(false);
+  it('extracts view mode from pathname with trailing slash', () => {
+    expect(getViewModeFromPathname('/app/quarterly/')).toBe('quarterly');
   });
 
-  it('keeps week but drops day and quarter when switching to weekly', () => {
-    const current = new URLSearchParams('view-mode=daily&week=10&day=5&year=2026&quarter=1');
+  it('returns null for non-view routes', () => {
+    expect(getViewModeFromPathname('/app')).toBeNull();
+    expect(getViewModeFromPathname('/app/')).toBeNull();
+    expect(getViewModeFromPathname('/app/admin')).toBeNull();
+    expect(getViewModeFromPathname('/app/documents')).toBeNull();
+    expect(getViewModeFromPathname('/app/goals')).toBeNull();
+    expect(getViewModeFromPathname('/app/profile')).toBeNull();
+  });
+});
 
-    const next = buildUrlParamsForViewModeChange(current, 'weekly', defaults);
+describe('buildDashboardViewHref', () => {
+  it('builds canonical view hrefs', () => {
+    expect(buildDashboardViewHref('focused')).toBe('/app/focused');
+    expect(buildDashboardViewHref('daily')).toBe('/app/daily');
+    expect(buildDashboardViewHref('weekly')).toBe('/app/weekly');
+    expect(buildDashboardViewHref('quarterly')).toBe('/app/quarterly');
+  });
+});
 
-    expect(next.get('view-mode')).toBe('weekly');
-    expect(next.get('year')).toBe('2026');
-    expect(next.get('week')).toBe('10');
-    expect(next.has('day')).toBe(false);
-    expect(next.has('quarter')).toBe(false);
+describe('buildDashboardHref', () => {
+  it('merges week updates and never emits view-mode', () => {
+    const current = new URLSearchParams('year=2026&view-mode=weekly');
+    const href = buildDashboardHref('weekly', current, { week: 11 });
+
+    expect(href).toBe('/app/weekly?year=2026&week=11');
+    expect(href).not.toContain('view-mode');
   });
 
-  it('keeps week and day when switching to daily', () => {
-    const current = new URLSearchParams('view-mode=focused&year=2026&quarter=3');
+  it('merges quarter updates and never emits view-mode', () => {
+    const current = new URLSearchParams('year=2026&view-mode=quarterly');
+    const href = buildDashboardHref('quarterly', current, { quarter: 3 });
 
-    const next = buildUrlParamsForViewModeChange(current, 'daily', defaults);
+    expect(href).toBe('/app/quarterly?year=2026&quarter=3');
+    expect(href).not.toContain('view-mode');
+  });
 
-    expect(next.get('view-mode')).toBe('daily');
-    expect(next.get('year')).toBe('2026');
-    expect(next.get('week')).toBe('24');
-    expect(next.get('day')).toBe(String(DayOfWeek.WEDNESDAY));
-    expect(next.has('quarter')).toBe(false);
+  it('returns clean path when no params', () => {
+    const current = new URLSearchParams();
+    const href = buildDashboardHref('weekly', current, {});
+
+    expect(href).toBe('/app/weekly');
+  });
+
+  it('handles focus-mode toggle', () => {
+    const current = new URLSearchParams('year=2026');
+    const href = buildDashboardHref('focused', current, { focusMode: true });
+
+    expect(href).toBe('/app/focused?year=2026&focus-mode=true');
+    expect(href).not.toContain('view-mode');
+  });
+
+  it('merges day update', () => {
+    const current = new URLSearchParams('year=2026&week=24');
+    const href = buildDashboardHref('daily', current, { day: DayOfWeek.WEDNESDAY });
+
+    expect(href).toBe('/app/daily?year=2026&week=24&day=3');
+    expect(href).not.toContain('view-mode');
+  });
+});
+
+describe('getLegacyViewModeRedirectHref', () => {
+  it('maps view-mode=daily to /app/daily', () => {
+    const params = new URLSearchParams('view-mode=daily&week=10');
+    expect(getLegacyViewModeRedirectHref(params)).toBe('/app/daily');
+  });
+
+  it('maps view-mode=weekly to /app/weekly', () => {
+    const params = new URLSearchParams('view-mode=weekly');
+    expect(getLegacyViewModeRedirectHref(params)).toBe('/app/weekly');
+  });
+
+  it('maps view-mode=quarterly to /app/quarterly', () => {
+    const params = new URLSearchParams('view-mode=quarterly');
+    expect(getLegacyViewModeRedirectHref(params)).toBe('/app/quarterly');
+  });
+
+  it('maps view-mode=focused to /app/focused', () => {
+    const params = new URLSearchParams('view-mode=focused');
+    expect(getLegacyViewModeRedirectHref(params)).toBe('/app/focused');
+  });
+
+  it('returns null when no view-mode param', () => {
+    const params = new URLSearchParams('week=10&year=2026');
+    expect(getLegacyViewModeRedirectHref(params)).toBeNull();
+  });
+
+  it('returns null for invalid view-mode', () => {
+    const params = new URLSearchParams('view-mode=invalid');
+    expect(getLegacyViewModeRedirectHref(params)).toBeNull();
   });
 });
 
 describe('applyDashboardUrlUpdates', () => {
-  it('merges partial updates onto existing params', () => {
+  it('merges partial updates onto existing params without view-mode', () => {
+    const current = new URLSearchParams('week=10&year=2026');
+    const next = applyDashboardUrlUpdates(current, { week: 11 });
+
+    expect(next.get('week')).toBe('11');
+    expect(next.has('view-mode')).toBe(false);
+  });
+
+  it('strips view-mode from existing params', () => {
     const current = new URLSearchParams('view-mode=weekly&week=10&year=2026');
     const next = applyDashboardUrlUpdates(current, { week: 11 });
 
     expect(next.get('week')).toBe('11');
-    expect(next.get('view-mode')).toBe('weekly');
+    expect(next.has('view-mode')).toBe(false);
   });
 });

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
@@ -1,7 +1,7 @@
 import type { ViewMode } from '@/components/molecules/focus/constants';
 import type { DayOfWeek } from '@/lib/constants';
 
-export const VIEW_MODES: readonly ViewMode[] = ['daily', 'weekly', 'quarterly', 'focused'];
+const VIEW_MODES: readonly ViewMode[] = ['daily', 'weekly', 'quarterly', 'focused'];
 
 export interface DashboardUrlUpdates {
   week?: number;
@@ -13,11 +13,6 @@ export interface DashboardUrlUpdates {
 
 export function isViewMode(value: string): value is ViewMode {
   return (VIEW_MODES as readonly string[]).includes(value);
-}
-
-export function parseViewMode(value: string | null | undefined, fallback: ViewMode): ViewMode {
-  if (value != null && isViewMode(value)) return value;
-  return fallback;
 }
 
 export function getViewModeFromPathname(pathname: string): ViewMode | null {
@@ -43,14 +38,15 @@ export function buildDashboardHref(
 }
 
 export function getLegacyViewModeRedirectHref(searchParams: URLSearchParams): string | null {
-  const viewMode = searchParams.get('view-mode');
-  if (viewMode && isViewMode(viewMode)) {
-    return buildDashboardViewHref(viewMode);
+  const raw = searchParams.get('view-mode');
+  if (raw != null && isViewMode(raw)) {
+    return buildDashboardViewHref(raw);
   }
   return null;
 }
 
-export function applyDashboardUrlUpdates(
+// fallow-ignore-next-line complexity
+function applyDashboardUrlUpdates(
   current: URLSearchParams,
   updates: DashboardUrlUpdates
 ): URLSearchParams {

--- a/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
+++ b/apps/webapp/src/lib/dashboard/dashboardUrlParams.ts
@@ -1,126 +1,62 @@
 import type { ViewMode } from '@/components/molecules/focus/constants';
-import { DayOfWeek } from '@/lib/constants';
-import { getQuarterFromWeek } from '@/lib/date/iso-week';
+import type { DayOfWeek } from '@/lib/constants';
 
-const VIEW_MODES: readonly ViewMode[] = ['daily', 'weekly', 'quarterly', 'focused'];
-
-export interface DashboardNavigationDefaults {
-  year: number;
-  quarter: 1 | 2 | 3 | 4;
-  week: number;
-  day: DayOfWeek;
-}
+export const VIEW_MODES: readonly ViewMode[] = ['daily', 'weekly', 'quarterly', 'focused'];
 
 export interface DashboardUrlUpdates {
   week?: number;
   day?: DayOfWeek;
-  viewMode?: ViewMode;
   year?: number;
   quarter?: number;
   focusMode?: boolean;
 }
 
-function parsePositiveInt(value: string | null): number | undefined {
-  if (value === null) {
-    return undefined;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return undefined;
-  }
-
-  return parsed;
+export function isViewMode(value: string): value is ViewMode {
+  return (VIEW_MODES as readonly string[]).includes(value);
 }
 
-function parseQuarter(value: string | null): 1 | 2 | 3 | 4 | undefined {
-  const parsed = parsePositiveInt(value);
-  if (parsed === undefined || parsed < 1 || parsed > 4) {
-    return undefined;
-  }
-
-  return parsed as 1 | 2 | 3 | 4;
-}
-
-function parseDay(value: string | null): DayOfWeek | undefined {
-  const parsed = parsePositiveInt(value);
-  if (parsed === undefined || parsed < DayOfWeek.MONDAY || parsed > DayOfWeek.SUNDAY) {
-    return undefined;
-  }
-
-  return parsed as DayOfWeek;
-}
-
-/** Parses a view-mode query value, falling back when missing or invalid. */
-export function parseViewMode(value: string | null, fallback: ViewMode): ViewMode {
-  if (value !== null && VIEW_MODES.includes(value as ViewMode)) {
-    return value as ViewMode;
-  }
-
+export function parseViewMode(value: string | null | undefined, fallback: ViewMode): ViewMode {
+  if (value != null && isViewMode(value)) return value;
   return fallback;
 }
 
-/**
- * Builds canonical dashboard URL search params for a view-mode change.
- *
- * When every navigation param is present in the URL, stale week/day/quarter values
- * can disagree and make view switches appear to do nothing. Each view mode keeps
- * only the params it needs and drops the rest.
- */
-// fallow-ignore-next-line complexity
-export function buildUrlParamsForViewModeChange(
-  current: URLSearchParams,
-  newViewMode: ViewMode,
-  defaults: DashboardNavigationDefaults
-): URLSearchParams {
-  const next = new URLSearchParams(current.toString());
-  next.set('view-mode', newViewMode);
-
-  const year = parsePositiveInt(current.get('year')) ?? defaults.year;
-  const week = parsePositiveInt(current.get('week')) ?? defaults.week;
-  const day = parseDay(current.get('day')) ?? defaults.day;
-  const quarter =
-    parseQuarter(current.get('quarter')) ?? getQuarterFromWeek(week) ?? defaults.quarter;
-
-  next.set('year', year.toString());
-
-  switch (newViewMode) {
-    case 'quarterly': {
-      next.set('quarter', quarter.toString());
-      next.delete('week');
-      next.delete('day');
-      break;
-    }
-    case 'weekly': {
-      next.set('week', week.toString());
-      next.delete('quarter');
-      next.delete('day');
-      break;
-    }
-    case 'daily': {
-      next.set('week', week.toString());
-      next.set('day', day.toString());
-      next.delete('quarter');
-      break;
-    }
-    case 'focused': {
-      next.delete('week');
-      next.delete('day');
-      next.delete('quarter');
-      break;
-    }
+export function getViewModeFromPathname(pathname: string): ViewMode | null {
+  const match = pathname.match(/^\/app\/(daily|weekly|quarterly|focused)(?:\/|$)/);
+  if (match) {
+    return match[1] as ViewMode;
   }
-
-  return next;
+  return null;
 }
 
-/** Applies partial dashboard navigation updates onto existing search params. */
-// fallow-ignore-next-line complexity
+export function buildDashboardViewHref(viewMode: ViewMode): string {
+  return `/app/${viewMode}`;
+}
+
+export function buildDashboardHref(
+  viewMode: ViewMode,
+  current: URLSearchParams,
+  updates: DashboardUrlUpdates
+): string {
+  const next = applyDashboardUrlUpdates(current, updates);
+  const qs = next.toString();
+  return qs ? `/app/${viewMode}?${qs}` : `/app/${viewMode}`;
+}
+
+export function getLegacyViewModeRedirectHref(searchParams: URLSearchParams): string | null {
+  const viewMode = searchParams.get('view-mode');
+  if (viewMode && isViewMode(viewMode)) {
+    return buildDashboardViewHref(viewMode);
+  }
+  return null;
+}
+
 export function applyDashboardUrlUpdates(
   current: URLSearchParams,
   updates: DashboardUrlUpdates
 ): URLSearchParams {
   const next = new URLSearchParams(current.toString());
+
+  next.delete('view-mode');
 
   if (updates.week !== undefined) {
     next.set('week', updates.week.toString());
@@ -128,10 +64,6 @@ export function applyDashboardUrlUpdates(
 
   if (updates.day !== undefined) {
     next.set('day', updates.day.toString());
-  }
-
-  if (updates.viewMode !== undefined) {
-    next.set('view-mode', updates.viewMode);
   }
 
   if (updates.year !== undefined) {


### PR DESCRIPTION
## Summary
- Move dashboard view mode from `?view-mode=` into path segments (`/app/quarterly`, `/app/weekly`, `/app/daily`, `/app/focused`)
- Activating a different view (Q/W/D/F or menus) navigates to a clean `/app/{mode}` URL with **no query params**
- `/app` redirects to the default view; legacy `?view-mode=` bookmarks resolve to the new path
- Extract shared `GoalDetailsPageShell` for full-page goal views (also updates their dashboard links to the new routes)

## Test plan
- [ ] Open `/app` — redirects to `/app/quarterly` (desktop) or `/app/focused` (mobile)
- [ ] Press Q / W / D / F — URL becomes `/app/quarterly|weekly|daily|focused` with no query string
- [ ] Within weekly/daily, use prev/next — query params update on the current view path
- [ ] Visit `/app?view-mode=weekly` — redirects to `/app/weekly`
- [ ] Visit `/app/admin` and `/app/documents` — still work (static routes unaffected)
- [ ] Visit `/app/not-a-view` — 404
- [ ] From a goal details page, use the context badge to return to weekly/quarterly dashboard on the new path


Made with [Cursor](https://cursor.com)