### PR TITLE
fix(pull-goals): show incomplete weekly goals in pull preview

### DIFF
--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.test.tsx
@@ -151,4 +151,22 @@ describe('PullGoalsPreviewDialog', () => {
 
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  it('renders weekly-only task as the weekly header without a duplicate bullet', () => {
+    renderDialog({
+      tasksFromPreviousWeek: [
+        {
+          id: 'weekly-1',
+          title: 'Weekly-only goal',
+          quarterlyGoal: { id: 'q1', title: 'Q Goal' },
+          weeklyGoal: { id: 'weekly-1', title: 'Weekly-only goal' },
+        },
+      ],
+    });
+
+    expect(screen.getByText('Weekly-only goal')).toBeInTheDocument();
+    // The weekly header appears (the weekly title)
+    const weeklyHeaders = screen.getAllByText('Weekly-only goal');
+    expect(weeklyHeaders.length).toBe(1);
+  });
 });

--- a/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
+++ b/apps/webapp/src/components/molecules/PullGoalsPreviewDialog.tsx
@@ -179,9 +179,11 @@ function TaskGroupList({ tasks }: { tasks: PreviewTask[] }) {
                   </div>
                 </h5>
                 <ul className="space-y-1">
-                  {weeklyGroup.tasks.map((task) => (
-                    <TaskPreviewItem key={task.id} task={task} />
-                  ))}
+                  {weeklyGroup.tasks
+                    .filter((task) => task.id !== weeklyGroup.weeklyGoal.id)
+                    .map((task) => (
+                      <TaskPreviewItem key={task.id} task={task} />
+                    ))}
                 </ul>
               </div>
             ))}

--- a/apps/webapp/src/hooks/usePullGoals.tsx
+++ b/apps/webapp/src/hooks/usePullGoals.tsx
@@ -1,8 +1,7 @@
 import { api } from '@workspace/backend/convex/_generated/api';
 import { DayOfWeek } from '@workspace/backend/src/constants';
 import { getQuarterWeeks } from '@workspace/backend/src/usecase/quarter';
-import { useMutation, useQuery } from 'convex/react';
-import { useConvex } from 'convex/react';
+import { useMutation, useQuery, useConvex } from 'convex/react';
 import { type ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useGoalActions } from './useGoalActions';
@@ -15,6 +14,7 @@ import {
 import { toast } from '@/components/ui/use-toast';
 import { useCurrentWeekInfo } from '@/hooks/useCurrentDateTime';
 import { getDayName } from '@/lib/constants';
+import { buildWeekPullPreviewTasks } from '@/lib/pull-goals/buildWeekPullPreviewTasks';
 import { useSession } from '@/modules/auth/useSession';
 
 interface UsePullGoalsProps {
@@ -169,50 +169,7 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
 
       if (!('canPull' in result) || !result.canPull) return [];
 
-      const weekTasks: PreviewTask[] = result.dailyGoalsToMove.map((dailyGoal) => {
-        const quarterlyStatus = result.quarterlyGoalsToUpdate.find(
-          (q) => q.id === dailyGoal.quarterlyGoalId
-        ) ?? { isStarred: false, isPinned: false };
-
-        return {
-          id: dailyGoal.id,
-          title: dailyGoal.title,
-          isComplete: false,
-          quarterlyGoal: {
-            id: dailyGoal.quarterlyGoalId ?? dailyGoal.weeklyGoalId,
-            title: dailyGoal.quarterlyGoalTitle ?? dailyGoal.weeklyGoalTitle,
-            isStarred: quarterlyStatus.isStarred,
-            isPinned: quarterlyStatus.isPinned,
-          },
-          weeklyGoal: {
-            id: dailyGoal.weeklyGoalId,
-            title: dailyGoal.weeklyGoalTitle,
-          },
-        };
-      });
-
-      // Also add adhoc goals from the preview
-      if (result.adhocGoalsToMove && result.adhocGoalsToMove.length > 0) {
-        const adhocTasks: PreviewTask[] = result.adhocGoalsToMove.map((adhoc) => ({
-          id: adhoc.id,
-          title: adhoc.title,
-          details: undefined,
-          isComplete: false,
-          quarterlyGoal: {
-            id: 'adhoc',
-            title: 'Adhoc Tasks',
-            isStarred: false,
-            isPinned: false,
-          },
-          weeklyGoal: {
-            id: `adhoc-domain-${adhoc.domainId || 'uncategorized'}`,
-            title: adhoc.domainName || 'Uncategorized',
-          },
-        }));
-        weekTasks.push(...adhocTasks);
-      }
-
-      return weekTasks;
+      return buildWeekPullPreviewTasks(result);
     },
     [sessionId, moveGoalsFromWeekMutation]
   );
@@ -246,7 +203,11 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
           moveOnlyIncomplete: true,
         });
 
-        if ('canMove' in dayPreviewData && dayPreviewData.canMove && dayPreviewData.tasks.length > 0) {
+        if (
+          'canMove' in dayPreviewData &&
+          dayPreviewData.canMove &&
+          dayPreviewData.tasks.length > 0
+        ) {
           tasks.push(...dayPreviewData.tasks);
         }
       }
@@ -403,9 +364,7 @@ export const usePullGoals = (_props: UsePullGoalsProps): UsePullGoalsReturn => {
     async (week: WeekRef) => {
       const currentFrom = fromWeekRef.current;
       const sameQuarter =
-        currentFrom &&
-        currentFrom.year === week.year &&
-        currentFrom.quarter === week.quarter;
+        currentFrom && currentFrom.year === week.year && currentFrom.quarter === week.quarter;
 
       // Clamp/clear From if it would be >= To
       if (!sameQuarter || !currentFrom || currentFrom.weekNumber >= week.weekNumber) {

--- a/apps/webapp/src/lib/pull-goals/buildWeekPullPreviewTasks.test.ts
+++ b/apps/webapp/src/lib/pull-goals/buildWeekPullPreviewTasks.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWeekPullPreviewTasks } from './buildWeekPullPreviewTasks';
+import type { WeekPullDryRunLike } from './buildWeekPullPreviewTasks';
+
+const baseQuarterlyGoals = [{ id: 'q-1', title: 'Q Goal', isStarred: false, isPinned: false }];
+
+describe('buildWeekPullPreviewTasks', () => {
+  it('includes incomplete weekly goals with no daily children', () => {
+    const result: WeekPullDryRunLike = {
+      dailyGoalsToMove: [],
+      weekStatesToCopy: [
+        {
+          id: 'weekly-1',
+          title: 'Ship incomplete weekly',
+          dailyGoalsCount: 0,
+          quarterlyGoalId: 'q-1',
+          quarterlyGoalTitle: 'Q Goal',
+        },
+      ],
+      quarterlyGoalsToUpdate: baseQuarterlyGoals,
+      adhocGoalsToMove: [],
+    };
+
+    const tasks = buildWeekPullPreviewTasks(result);
+
+    expect(tasks).toEqual([
+      expect.objectContaining({
+        id: 'weekly-1',
+        title: 'Ship incomplete weekly',
+        weeklyGoal: { id: 'weekly-1', title: 'Ship incomplete weekly' },
+        quarterlyGoal: expect.objectContaining({ id: 'q-1', title: 'Q Goal' }),
+      }),
+    ]);
+  });
+
+  it('does not duplicate a weekly that already has daily tasks', () => {
+    const result: WeekPullDryRunLike = {
+      dailyGoalsToMove: [
+        {
+          id: 'daily-1',
+          title: 'A daily task',
+          weeklyGoalId: 'weekly-1',
+          weeklyGoalTitle: 'W Goal',
+          quarterlyGoalId: 'q-1',
+          quarterlyGoalTitle: 'Q Goal',
+        },
+      ],
+      weekStatesToCopy: [
+        {
+          id: 'weekly-1',
+          title: 'W Goal',
+          dailyGoalsCount: 1,
+          quarterlyGoalId: 'q-1',
+          quarterlyGoalTitle: 'Q Goal',
+        },
+      ],
+      quarterlyGoalsToUpdate: baseQuarterlyGoals,
+      adhocGoalsToMove: [],
+    };
+
+    const tasks = buildWeekPullPreviewTasks(result);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toEqual(
+      expect.objectContaining({
+        id: 'daily-1',
+        title: 'A daily task',
+        weeklyGoal: { id: 'weekly-1', title: 'W Goal' },
+      })
+    );
+  });
+
+  it('still includes adhoc tasks', () => {
+    const result: WeekPullDryRunLike = {
+      dailyGoalsToMove: [],
+      weekStatesToCopy: [],
+      quarterlyGoalsToUpdate: [],
+      adhocGoalsToMove: [
+        {
+          id: 'adhoc-1',
+          title: 'Adhoc task',
+          domainId: 'domain-1',
+          domainName: 'My Domain',
+        },
+      ],
+    };
+
+    const tasks = buildWeekPullPreviewTasks(result);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toEqual(
+      expect.objectContaining({
+        id: 'adhoc-1',
+        title: 'Adhoc task',
+        weeklyGoal: { id: 'adhoc-domain-domain-1', title: 'My Domain' },
+      })
+    );
+  });
+
+  it('combines daily, weekly-only, and adhoc tasks', () => {
+    const result: WeekPullDryRunLike = {
+      dailyGoalsToMove: [
+        {
+          id: 'daily-1',
+          title: 'Daily task',
+          weeklyGoalId: 'weekly-1',
+          weeklyGoalTitle: 'W1 Goal',
+          quarterlyGoalId: 'q-1',
+          quarterlyGoalTitle: 'Q1',
+        },
+      ],
+      weekStatesToCopy: [
+        {
+          id: 'weekly-2',
+          title: 'Weekly-only task',
+          dailyGoalsCount: 0,
+          quarterlyGoalId: 'q-2',
+          quarterlyGoalTitle: 'Q2',
+        },
+      ],
+      quarterlyGoalsToUpdate: [
+        { id: 'q-1', title: 'Q1', isStarred: false, isPinned: false },
+        { id: 'q-2', title: 'Q2', isStarred: true, isPinned: false },
+      ],
+      adhocGoalsToMove: [
+        {
+          id: 'adhoc-1',
+          title: 'Adhoc task',
+        },
+      ],
+    };
+
+    const tasks = buildWeekPullPreviewTasks(result);
+
+    expect(tasks).toHaveLength(3);
+    expect(tasks.map((t) => t.id)).toEqual(['daily-1', 'weekly-2', 'adhoc-1']);
+  });
+
+  it('handles weekStatesToCopy without quarterlyGoalId gracefully', () => {
+    const result: WeekPullDryRunLike = {
+      dailyGoalsToMove: [],
+      weekStatesToCopy: [
+        {
+          id: 'weekly-1',
+          title: 'Orphan weekly',
+          dailyGoalsCount: 0,
+        },
+      ],
+      quarterlyGoalsToUpdate: [],
+      adhocGoalsToMove: [],
+    };
+
+    const tasks = buildWeekPullPreviewTasks(result);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].quarterlyGoal.id).toBe('');
+    expect(tasks[0].quarterlyGoal.title).toBe('Quarterly Goal');
+  });
+});

--- a/apps/webapp/src/lib/pull-goals/buildWeekPullPreviewTasks.ts
+++ b/apps/webapp/src/lib/pull-goals/buildWeekPullPreviewTasks.ts
@@ -1,0 +1,115 @@
+import type { PreviewTask } from '@/components/molecules/PullGoalsPreviewDialog';
+
+export type WeekPullDryRunLike = {
+  dailyGoalsToMove: {
+    id: string;
+    title: string;
+    weeklyGoalId: string;
+    weeklyGoalTitle: string;
+    quarterlyGoalId?: string;
+    quarterlyGoalTitle?: string;
+  }[];
+  weekStatesToCopy: {
+    id: string;
+    title: string;
+    dailyGoalsCount: number;
+    quarterlyGoalId?: string;
+    quarterlyGoalTitle?: string;
+  }[];
+  quarterlyGoalsToUpdate: {
+    id: string;
+    title: string;
+    isStarred: boolean;
+    isPinned: boolean;
+  }[];
+  adhocGoalsToMove: {
+    id: string;
+    title: string;
+    domainId?: string;
+    domainName?: string;
+  }[];
+};
+
+function weeklyIdsWithDailyTasks(dailyGoals: WeekPullDryRunLike['dailyGoalsToMove']): Set<string> {
+  return new Set(dailyGoals.map((d) => d.weeklyGoalId));
+}
+
+function buildQuarterlyStatus(
+  quarterlyGoalId: string | undefined,
+  quarterlyGoalTitle: string | undefined,
+  quarterlyGoalsToUpdate: WeekPullDryRunLike['quarterlyGoalsToUpdate']
+): PreviewTask['quarterlyGoal'] {
+  const quarterlyStatus = quarterlyGoalId
+    ? quarterlyGoalsToUpdate.find((q) => q.id === quarterlyGoalId)
+    : undefined;
+
+  return {
+    id: quarterlyGoalId ?? '',
+    title: quarterlyGoalTitle ?? 'Quarterly Goal',
+    isStarred: quarterlyStatus?.isStarred ?? false,
+    isPinned: quarterlyStatus?.isPinned ?? false,
+  };
+}
+
+export function buildWeekPullPreviewTasks(result: WeekPullDryRunLike): PreviewTask[] {
+  const tasks: PreviewTask[] = [];
+
+  // 1) Map dailyGoalsToMove → PreviewTask
+  for (const dailyGoal of result.dailyGoalsToMove) {
+    tasks.push({
+      id: dailyGoal.id,
+      title: dailyGoal.title,
+      quarterlyGoal: buildQuarterlyStatus(
+        dailyGoal.quarterlyGoalId,
+        dailyGoal.quarterlyGoalTitle,
+        result.quarterlyGoalsToUpdate
+      ),
+      weeklyGoal: {
+        id: dailyGoal.weeklyGoalId,
+        title: dailyGoal.weeklyGoalTitle,
+      },
+    });
+  }
+
+  // 2) For each weekStatesToCopy whose weekly id is NOT already represented by a daily task,
+  //    append a PreviewTask for the weekly goal itself (no daily children to show).
+  const weeklyWithDailyIds = weeklyIdsWithDailyTasks(result.dailyGoalsToMove);
+  for (const weekly of result.weekStatesToCopy) {
+    if (weeklyWithDailyIds.has(weekly.id)) continue;
+
+    tasks.push({
+      id: weekly.id,
+      title: weekly.title,
+      quarterlyGoal: buildQuarterlyStatus(
+        weekly.quarterlyGoalId,
+        weekly.quarterlyGoalTitle,
+        result.quarterlyGoalsToUpdate
+      ),
+      weeklyGoal: {
+        id: weekly.id,
+        title: weekly.title,
+      },
+    });
+  }
+
+  // 3) Append adhoc tasks
+  for (const adhoc of result.adhocGoalsToMove) {
+    tasks.push({
+      id: adhoc.id,
+      title: adhoc.title,
+      details: undefined,
+      quarterlyGoal: {
+        id: 'adhoc',
+        title: 'Adhoc Tasks',
+        isStarred: false,
+        isPinned: false,
+      },
+      weeklyGoal: {
+        id: `adhoc-domain-${adhoc.domainId || 'uncategorized'}`,
+        title: adhoc.domainName || 'Uncategorized',
+      },
+    });
+  }
+
+  return tasks;
+}

--- a/services/backend/convex/goal.spec.ts
+++ b/services/backend/convex/goal.spec.ts
@@ -103,6 +103,7 @@ describe('moveGoalsFromWeek', () => {
       isDryRun: true,
       weekStatesToCopy: [
         {
+          id: weeklyGoalId,
           title: 'Goal weekly',
           carryOver: {
             type: 'week',
@@ -114,6 +115,7 @@ describe('moveGoalsFromWeek', () => {
           },
           dailyGoalsCount: 1,
           quarterlyGoalId,
+          quarterlyGoalTitle: 'Goal quarterly',
         },
       ],
       dailyGoalsToMove: [
@@ -361,7 +363,6 @@ describe('moveGoalsFromWeek', () => {
       from: { year: 2024, quarter: 1, weekNumber: 1 },
       to: { year: 2024, quarter: 1, weekNumber: 4 },
       dryRun: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     })) as any;
 
     // The stale clone must not appear in weekStatesToCopy
@@ -376,7 +377,6 @@ describe('moveGoalsFromWeek', () => {
       from: { year: 2024, quarter: 1, weekNumber: 3 },
       to: { year: 2024, quarter: 1, weekNumber: 4 },
       dryRun: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     })) as any;
 
     expect(latestPreview.canPull).toBe(true);
@@ -410,12 +410,85 @@ describe('moveGoalsFromWeek', () => {
       (g: GoalWithDetailsAndChildren) => g._id === quarterlyGoalId
     );
     const seriesClonesInWeek4 = (qg?.children ?? []).filter(
-      (wg: GoalWithDetailsAndChildren) =>
-        wg.carryOver?.fromGoal.rootGoalId === weeklyGoalId
+      (wg: GoalWithDetailsAndChildren) => wg.carryOver?.fromGoal.rootGoalId === weeklyGoalId
     );
 
     // Only ONE clone in week 4 (from the latest snapshot, not the two earlier ones)
     expect(seriesClonesInWeek4).toHaveLength(1);
+  });
+
+  test('dry run includes incomplete weekly goal with no daily children', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const quarterlyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Quarterly);
+    const weeklyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Weekly, quarterlyGoalId);
+    // Do NOT create daily children. Weekly is incomplete by default.
+
+    const previewResult = await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 1 },
+      to: { year: 2024, quarter: 1, weekNumber: 2 },
+      dryRun: true,
+    });
+
+    expect((previewResult as any).canPull).toBe(true);
+    expect((previewResult as any).weekStatesToCopy).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: weeklyGoalId,
+          title: 'Goal weekly',
+          dailyGoalsCount: 0,
+          quarterlyGoalId,
+        }),
+      ])
+    );
+    expect((previewResult as any).dailyGoalsToMove).toEqual([]);
+  });
+
+  test('dry run includes incomplete weekly goal when all daily children are complete', async () => {
+    const ctx = convexTest(schema);
+    const sessionId = await createTestSession(ctx);
+
+    const quarterlyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Quarterly);
+    const weeklyGoalId = await createMockGoal(ctx, sessionId, GoalDepth.Weekly, quarterlyGoalId);
+
+    // Create daily goals and mark them as complete
+    const dailyGoal1Id = await createMockGoal(ctx, sessionId, GoalDepth.Daily, weeklyGoalId);
+    const dailyGoal2Id = await createMockGoal(ctx, sessionId, GoalDepth.Daily, weeklyGoalId);
+
+    await ctx.mutation(api.dashboard.toggleGoalCompletion, {
+      sessionId,
+      goalId: dailyGoal1Id,
+      weekNumber: 1,
+      isComplete: true,
+    });
+    await ctx.mutation(api.dashboard.toggleGoalCompletion, {
+      sessionId,
+      goalId: dailyGoal2Id,
+      weekNumber: 1,
+      isComplete: true,
+    });
+
+    const previewResult = await ctx.mutation(api.goal.moveGoalsFromWeek, {
+      sessionId,
+      from: { year: 2024, quarter: 1, weekNumber: 1 },
+      to: { year: 2024, quarter: 1, weekNumber: 2 },
+      dryRun: true,
+    });
+
+    expect((previewResult as any).canPull).toBe(true);
+    expect((previewResult as any).weekStatesToCopy).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: weeklyGoalId,
+          title: 'Goal weekly',
+          dailyGoalsCount: 0,
+          quarterlyGoalId,
+        }),
+      ])
+    );
+    expect((previewResult as any).dailyGoalsToMove).toEqual([]);
   });
 });
 

--- a/services/backend/src/usecase/moveGoalsFromWeek/moveGoalsFromWeek.ts
+++ b/services/backend/src/usecase/moveGoalsFromWeek/moveGoalsFromWeek.ts
@@ -113,10 +113,7 @@ export async function moveGoalsFromWeekUsecase<T extends MoveGoalsFromWeekArgs>(
     const newerStates = await ctx.db
       .query('goalStateByWeek')
       .withIndex('by_user_and_year_and_quarter_and_week', (q) =>
-        q
-          .eq('userId', userId)
-          .eq('year', from.year)
-          .eq('quarter', from.quarter)
+        q.eq('userId', userId).eq('year', from.year).eq('quarter', from.quarter)
       )
       .filter((q) => q.gt(q.field('weekNumber'), from.weekNumber))
       .collect();
@@ -595,6 +592,7 @@ function createWeeklyGoalCarryOver(
       },
     },
     quarterlyGoalId: quarterlyGoal?._id,
+    quarterlyGoalTitle: quarterlyGoal?.title,
     dailyGoalsToMove,
   };
 
@@ -626,6 +624,7 @@ export async function generateDryRunPreview(
       carryOver: item.carryOver,
       dailyGoalsCount: item.dailyGoalsToMove.length,
       quarterlyGoalId: item.quarterlyGoalId,
+      quarterlyGoalTitle: item.quarterlyGoalTitle,
     }));
 
   // Filter out skipped goals from weekStatesToCopy
@@ -642,10 +641,12 @@ export async function generateDryRunPreview(
     canPull:
       goalsToActuallyMove.length > 0 || dailyGoalsToMove.length > 0 || adhocGoalsToMove.length > 0,
     weekStatesToCopy: goalsToActuallyMove.map((item) => ({
+      id: item.originalGoal._id,
       title: item.originalGoal.title,
       carryOver: item.carryOver,
       dailyGoalsCount: item.dailyGoalsToMove.length,
       quarterlyGoalId: item.quarterlyGoalId,
+      quarterlyGoalTitle: item.quarterlyGoalTitle,
     })),
     dailyGoalsToMove: dailyGoalsToMove.map((item) => ({
       id: item.goal._id,

--- a/services/backend/src/usecase/moveGoalsFromWeek/types.ts
+++ b/services/backend/src/usecase/moveGoalsFromWeek/types.ts
@@ -80,6 +80,7 @@ export type WeekStateToCopy = {
   weekState: Doc<'goalStateByWeek'>;
   carryOver: CarryOver;
   quarterlyGoalId?: Id<'goals'>;
+  quarterlyGoalTitle?: string;
   dailyGoalsToMove: DailyGoalToMove[];
 };
 
@@ -90,10 +91,12 @@ export type GoalSummary = {
 };
 
 export type WeekStateSummary = {
+  id: Id<'goals'>;
   title: string;
   carryOver: CarryOver;
   dailyGoalsCount: number;
   quarterlyGoalId?: Id<'goals'>;
+  quarterlyGoalTitle?: string;
 };
 
 export type DailyGoalSummary = {
@@ -128,6 +131,7 @@ export type SkippedGoalSummary = {
   carryOver: CarryOver;
   dailyGoalsCount: number;
   quarterlyGoalId?: Id<'goals'>;
+  quarterlyGoalTitle?: string;
 };
 
 export type BaseGoalMoveResult = {


### PR DESCRIPTION
## Summary
- Incomplete weekly goals (no incomplete daily children) were already returned in `weekStatesToCopy` by the backend, but the Pull Goals preview only mapped `dailyGoalsToMove`, so they never appeared in the UI
- Add pure mapper `buildWeekPullPreviewTasks` that includes weekly-only incompletes, and enrich dry-run `WeekStateSummary` with `id` / `quarterlyGoalTitle`
- Dialog skips duplicate bullets when the task is the weekly goal itself (header alone is enough)

## Test plan
- [ ] Create an incomplete weekly goal in week 28 with no daily children (or only complete dailies)
- [ ] In week 29, open Pull Incomplete Goals with From = week 28
- [ ] Confirm the incomplete weekly title appears in the preview
- [ ] Confirm a weekly that has incomplete dailies still shows those dailies (no duplicate weekly bullet)
- [ ] Confirm adhoc incomplete goals still appear
- [ ] Confirm Pull still executes and carries the weekly into week 29


Made with [Cursor](https://cursor.com)