### PR TITLE
fix(initiativebadge): remove artificial max-w truncation on initiative label

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeBadge.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeBadge.tsx
@@ -10,7 +10,7 @@ export function InitiativeBadge({ title, className }: InitiativeBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center max-w-[8rem] truncate px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider',
+        'inline-flex items-center whitespace-nowrap px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider',
         'bg-primary/10 text-primary',
         className
       )}


### PR DESCRIPTION
## Summary

`InitiativeBadge` hard-caps width at `max-w-[8rem]` with `truncate`, causing labels like "GDP Migration" to be cut off with ellipsis in the focus view and goal list rows.

## Change

Removed `max-w-[8rem] truncate` from the badge classes and added `whitespace-nowrap` so the pill stays single-line while growing to fit the full title.

The flex priority was already correct: goal title has `flex-1 min-w-0 truncate`, badge parent passes `flex-shrink-0`.

## Test Plan

1. **Manual** — Open focus view with an initiative whose title exceeds 8rem (e.g. "GDP Migration"). Verify the full title is visible without ellipsis.
2. **Manual** — Check weekly/daily/quarterly/adhoc goal list views (via `InitiativeBadgeForGoal`) to confirm titles render fully there too.
3. **Manual** — Verify very long initiative names push the goal title to truncate (acceptable per requirements).
4. **Existing tests** — `pnpm test --filter=webapp` passes (247 tests, 34 files).
5. **Typecheck** — `pnpm typecheck` passes.

## File changed

- `apps/webapp/src/components/atoms/InitiativeBadge.tsx` — one-line class change