### PR TITLE
feat(ui): inline edit goal title and details instead of opening edit modal

### DIFF
--- a/apps/webapp/src/components/molecules/focus/AdhocGoalQuickViewModal.tsx
+++ b/apps/webapp/src/components/molecules/focus/AdhocGoalQuickViewModal.tsx
@@ -17,7 +17,6 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../goal-details-popover/view/components';
 
 import { GoalStatusIcons } from '@/components/atoms/GoalStatusIcons';
@@ -32,7 +31,7 @@ import { GoalType } from '@/domain/goal-actions';
 import { buildAdhocGoalMutationArgs } from '@/domain/goal-updates';
 import { useAdhocGoals } from '@/hooks/useAdhocGoals';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useAdhocGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useAdhocGoalDetailsSave, useGoalTitleSave } from '@/hooks/useGoalDetailsSave';
 import { useSession } from '@/modules/auth/useSession';
 
 /**
@@ -204,7 +203,6 @@ function AdhocGoalQuickViewContent({
   const { sessionId } = useSession();
   const { updateAdhocGoal, deleteAdhocGoal, createAdhocGoal } = useAdhocGoals(sessionId);
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const isComplete = goal.isComplete;
 
   /**
@@ -226,6 +224,8 @@ function AdhocGoalQuickViewContent({
     },
     [goal._id, updateAdhocGoal]
   );
+
+  const handleTitleSave = useGoalTitleSave(handleSave, goal);
 
   /**
    * Toggles the completion status of the main adhoc goal.
@@ -360,7 +360,7 @@ function AdhocGoalQuickViewContent({
                 onToggleBacklog={handleToggleBacklog}
               />
             }
-            onTitleClick={onTitleClick}
+            onTitleSave={handleTitleSave}
           />
 
           {adhocGoalProp.domain && (
@@ -392,7 +392,6 @@ function AdhocGoalQuickViewContent({
                 details={goal.details ?? ''}
                 onDetailsChange={handleDetailsChange}
                 showSeparator={false}
-                onEditClick={onEditClick}
               />
               <Separator className="my-4" />
 

--- a/apps/webapp/src/components/molecules/focus/GoalQuickViewModal.tsx
+++ b/apps/webapp/src/components/molecules/focus/GoalQuickViewModal.tsx
@@ -19,7 +19,6 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../goal-details-popover/view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -41,7 +40,7 @@ import { resolveGoalType } from '@/domain/goal-actions';
 import { buildStructuredGoalMutationArgs } from '@/domain/goal-updates';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
 import { useGoalActions } from '@/hooks/useGoalActions';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 import { DayOfWeek, getDayName } from '@/lib/constants';
 import { useSession } from '@/modules/auth/useSession';
@@ -126,7 +125,6 @@ function GoalQuickViewContentInternal({
   const { weekNumber, year, quarter, createWeeklyGoalOptimistic, createDailyGoalOptimistic } =
     useWeek();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const isComplete = goal.isComplete;
 
   // State for creating child goals
@@ -165,6 +163,8 @@ function GoalQuickViewContentInternal({
     },
     [goal._id, goalActions]
   );
+
+  const handleTitleSave = useGoalTitleSave(handleSave, goal);
 
   const handleToggleComplete = useCallback(async () => {
     await goalActions.toggleGoalCompletion({
@@ -262,7 +262,7 @@ function GoalQuickViewContentInternal({
             onToggleComplete={handleToggleComplete}
             statusControls={<GoalStatusIcons goalId={goal._id} />}
             actionMenu={<GoalActionMenuNew onSave={handleSave} goalType={resolveGoalType(goal)} />}
-            onTitleClick={onTitleClick}
+            onTitleSave={handleTitleSave}
           />
 
           {isComplete && goal.completedAt && <GoalCompletionDate completedAt={goal.completedAt} />}
@@ -288,7 +288,6 @@ function GoalQuickViewContentInternal({
                 details={goal.details ?? ''}
                 onDetailsChange={handleDetailsChange}
                 showSeparator={false}
-                onEditClick={onEditClick}
               />
 
               {/* Weekly Goals section for quarterly goals */}

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopover.tsx
@@ -16,7 +16,6 @@ import {
   GoalHeader,
   useGoalDisplayContext,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -27,7 +26,7 @@ import { useGoalContext } from '@/contexts/GoalContext';
 import { FireGoalsProvider } from '@/contexts/GoalStatusContext';
 import { GoalType } from '@/domain/goal-actions';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useAdhocGoalDetailsSaveViaHandler } from '@/hooks/useGoalDetailsSave';
+import { useAdhocGoalDetailsSaveViaHandler, useGoalTitleSave } from '@/hooks/useGoalDetailsSave';
 import type { GoalCompletionHandler, GoalSaveHandler } from '@/models/goal-handlers';
 
 export interface AdhocGoalPopoverProps {
@@ -150,10 +149,10 @@ function AdhocGoalPopoverContentInner({
 }: AdhocGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
 
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
   const handleDetailsChange = useAdhocGoalDetailsSaveViaHandler(onSave, goal);
 
   // Shared content for both popover and fullscreen modes
@@ -173,7 +172,7 @@ function AdhocGoalPopoverContentInner({
           />
         }
         statusControls={<GoalStatusIcons goalId={goal._id} />}
-        onTitleClick={onTitleClick}
+        onTitleSave={handleTitleSave}
       />
 
       {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -200,7 +199,6 @@ function AdhocGoalPopoverContentInner({
             details={goal.details ?? ''}
             onDetailsChange={handleDetailsChange}
             showSeparator={false}
-            onEditClick={onEditClick}
           />
 
           {/* Sub-tasks section */}

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopoverContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/AdhocGoalPopoverContent.tsx
@@ -26,7 +26,6 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 
 import { GoalStatusIcons } from '@/components/atoms/GoalStatusIcons';
@@ -38,7 +37,7 @@ import { GoalType } from '@/domain/goal-actions';
 import { buildAdhocGoalMutationArgs } from '@/domain/goal-updates';
 import { useAdhocGoals } from '@/hooks/useAdhocGoals';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useAdhocGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useAdhocGoalDetailsSave, useGoalTitleSave } from '@/hooks/useGoalDetailsSave';
 import { useSession } from '@/modules/auth/useSession';
 
 /**
@@ -78,7 +77,8 @@ interface AdhocGoalPopoverContentInnerProps {
     title: string,
     details?: string,
     dueDate?: number,
-    domainId?: Id<'domains'> | null
+    domainId?: Id<'domains'> | null,
+    initiativeId?: Id<'initiatives'> | null
   ) => Promise<void>;
   /** Handler for updating goal details content */
   onDetailsChange: (newDetails: string) => void;
@@ -276,8 +276,8 @@ function AdhocGoalPopoverContentInner({
 }: AdhocGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { handleNestedActiveChange } = useDialogEscapeHandler();
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
 
   return (
     <>
@@ -296,7 +296,7 @@ function AdhocGoalPopoverContentInner({
             />
           }
           statusControls={<GoalStatusIcons goalId={goal._id} />}
-          onTitleClick={onTitleClick}
+          onTitleSave={handleTitleSave}
         />
 
         {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -329,7 +329,6 @@ function AdhocGoalPopoverContentInner({
               details={goal.details ?? ''}
               onDetailsChange={onDetailsChange}
               showSeparator={false}
-              onEditClick={onEditClick}
             />
 
             <AdhocSubGoalsList

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/DailyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/DailyGoalPopover.tsx
@@ -17,7 +17,6 @@ import {
   GoalInitiativeField,
   useGoalDisplayContext,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -29,7 +28,7 @@ import { useGoalContext } from '@/contexts/GoalContext';
 import { FireGoalsProvider } from '@/contexts/GoalStatusContext';
 import { GoalType } from '@/domain/goal-actions';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 import type { GoalCompletionHandler, GoalSaveHandler } from '@/models/goal-handlers';
 
@@ -112,11 +111,11 @@ function DailyGoalPopoverContentInner({
 }: DailyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter } = useWeek();
 
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
   const handleDetailsChange = useStructuredGoalDetailsSave(onSave, goal);
 
   const handleInitiativeChange = useCallback(
@@ -136,7 +135,7 @@ function DailyGoalPopoverContentInner({
         onToggleComplete={onToggleComplete}
         statusControls={<GoalStatusIcons goalId={goal._id} />}
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Daily} />}
-        onTitleClick={onTitleClick}
+        onTitleSave={handleTitleSave}
       />
 
       {domain && <GoalDomainDisplay domain={domain} weekNumber={weekNumber} />}
@@ -167,7 +166,6 @@ function DailyGoalPopoverContentInner({
             details={goal.details ?? ''}
             onDetailsChange={handleDetailsChange}
             showSeparator={false}
-            onEditClick={onEditClick}
           />
 
           {additionalContent && (

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/QuarterlyGoalPopover.tsx
@@ -16,7 +16,6 @@ import {
   GoalStatusIndicators,
   useGoalDisplayContext,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -29,7 +28,7 @@ import { useGoalContext } from '@/contexts/GoalContext';
 import { FireGoalsProvider } from '@/contexts/GoalStatusContext';
 import { GoalType } from '@/domain/goal-actions';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 import type { GoalCompletionHandler, GoalSaveHandler } from '@/models/goal-handlers';
 
@@ -165,13 +164,13 @@ function QuarterlyGoalPopoverContentInner({
 }: QuarterlyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter, weekNumber } = useWeek();
 
   const hasChildren = goal.children && goal.children.length > 0;
 
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
   const handleDetailsChange = useStructuredGoalDetailsSave(onSave, goal);
 
   // Shared content for both popover and fullscreen modes
@@ -195,7 +194,7 @@ function QuarterlyGoalPopoverContentInner({
           </div>
         }
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Quarterly} />}
-        onTitleClick={onTitleClick}
+        onTitleSave={handleTitleSave}
       />
 
       <GoalStatusIndicators isStarred={isStarred} isPinned={isPinned} />
@@ -220,7 +219,6 @@ function QuarterlyGoalPopoverContentInner({
             details={goal.details ?? ''}
             onDetailsChange={handleDetailsChange}
             showSeparator={false}
-            onEditClick={onEditClick}
           />
 
           <GoalChildrenSection

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/StandardGoalPopoverContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/StandardGoalPopoverContent.tsx
@@ -26,7 +26,6 @@ import {
   GoalInitiativeField,
   GoalStatusIndicators,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -40,7 +39,7 @@ import { GoalType } from '@/domain/goal-actions';
 import { buildStructuredGoalMutationArgs } from '@/domain/goal-updates';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
 import { useGoalActions } from '@/hooks/useGoalActions';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 
 /**
@@ -74,7 +73,13 @@ interface StandardGoalPopoverContentInnerProps {
   /** Handler for toggling goal completion */
   onToggleComplete: () => Promise<void>;
   /** Handler for saving goal updates */
-  onSave: (title: string, details?: string, dueDate?: number) => Promise<void>;
+  onSave: (
+    title: string,
+    details?: string,
+    dueDate?: number,
+    domainId?: Id<'domains'> | null,
+    initiativeId?: Id<'initiatives'> | null
+  ) => Promise<void>;
   /** Handler for updating goal details content */
   onDetailsChange: (newDetails: string) => void;
   /** Current value of the new weekly goal input */
@@ -244,8 +249,8 @@ function StandardGoalPopoverContentInner({
   const { goal } = useGoalContext();
   const { year, quarter, weekNumber } = useWeek();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { handleNestedActiveChange } = useDialogEscapeHandler();
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
 
   return (
     <>
@@ -268,7 +273,7 @@ function StandardGoalPopoverContentInner({
             </div>
           }
           actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Quarterly} />}
-          onTitleClick={onTitleClick}
+          onTitleSave={handleTitleSave}
         />
 
         <GoalStatusIndicators isStarred={isStarred} isPinned={isPinned} />
@@ -299,7 +304,6 @@ function StandardGoalPopoverContentInner({
               details={goal.details ?? ''}
               onDetailsChange={onDetailsChange}
               showSeparator={false}
-              onEditClick={onEditClick}
             />
 
             <GoalChildrenSection

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPageContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPageContent.tsx
@@ -27,7 +27,6 @@ import {
   GoalHeader,
   GoalInitiativeField,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 
 import { CreateGoalInput } from '@/components/atoms/CreateGoalInput';
@@ -44,7 +43,7 @@ import { FireGoalsProvider } from '@/contexts/GoalStatusContext';
 import { GoalType } from '@/domain/goal-actions';
 import { buildStructuredGoalMutationArgs } from '@/domain/goal-updates';
 import { useGoalActions } from '@/hooks/useGoalActions';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 import { DayOfWeek, getDayName } from '@/lib/constants';
 import { useSession } from '@/modules/auth/useSession';
@@ -195,7 +194,13 @@ interface WeeklyGoalPageContentInnerProps {
   /** Whether the goal has child daily goals */
   hasChildren: boolean;
   /** Handler for saving goal updates */
-  onSave: (title: string, details?: string, dueDate?: number) => Promise<void>;
+  onSave: (
+    title: string,
+    details?: string,
+    dueDate?: number,
+    domainId?: Id<'domains'> | null,
+    initiativeId?: Id<'initiatives'> | null
+  ) => Promise<void>;
   /** Handler for toggling goal completion */
   onToggleComplete: () => Promise<void>;
   /** Handler for updating goal details content */
@@ -235,7 +240,7 @@ function WeeklyGoalPageContentInner({
 }: WeeklyGoalPageContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
 
   return (
     <>
@@ -246,7 +251,7 @@ function WeeklyGoalPageContentInner({
           onToggleComplete={onToggleComplete}
           statusControls={<GoalStatusIcons goalId={goal._id} />}
           actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Weekly} />}
-          onTitleClick={onTitleClick}
+          onTitleSave={handleTitleSave}
         />
 
         <GoalCreatedDate createdAt={goal._creationTime} />
@@ -264,7 +269,6 @@ function WeeklyGoalPageContentInner({
           title={goal.title}
           details={goal.details ?? ''}
           onDetailsChange={onDetailsChange}
-          onEditClick={onEditClick}
         />
 
         <GoalChildrenSection

--- a/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPopover.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/variants/WeeklyGoalPopover.tsx
@@ -16,7 +16,6 @@ import {
   GoalHeader,
   useGoalDisplayContext,
   useGoalEditContext,
-  useStartEditingGoal,
 } from '../view/components';
 import { GoalDetailsPopoverView, GoalPopoverTrigger } from '../view/GoalDetailsPopoverView';
 
@@ -35,7 +34,7 @@ import { useGoalContext } from '@/contexts/GoalContext';
 import { FireGoalsProvider } from '@/contexts/GoalStatusContext';
 import { GoalType } from '@/domain/goal-actions';
 import { useDialogEscapeHandler } from '@/hooks/useDialogEscapeHandler';
-import { useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
+import { useGoalTitleSave, useStructuredGoalDetailsSave } from '@/hooks/useGoalDetailsSave';
 import { useWeek } from '@/hooks/useWeek';
 import { DayOfWeek, getDayName } from '@/lib/constants';
 import type { GoalCompletionHandler, GoalSaveHandler } from '@/models/goal-handlers';
@@ -155,13 +154,13 @@ function WeeklyGoalPopoverContentInner({
 }: WeeklyGoalPopoverContentInnerProps) {
   const { goal } = useGoalContext();
   const { isEditing, editingGoal, stopEditing } = useGoalEditContext();
-  const { onTitleClick, onEditClick } = useStartEditingGoal();
   const { isFullScreenOpen, closeFullScreen } = useGoalDisplayContext();
   const { handleEscapeKeyDown, handleNestedActiveChange } = useDialogEscapeHandler();
   const { year, quarter, weekNumber } = useWeek();
 
   const hasChildren = goal.children && goal.children.length > 0;
 
+  const handleTitleSave = useGoalTitleSave(onSave, goal);
   const handleDetailsChange = useStructuredGoalDetailsSave(onSave, goal);
 
   // Shared content for both popover and fullscreen modes
@@ -174,7 +173,7 @@ function WeeklyGoalPopoverContentInner({
         onToggleComplete={onToggleComplete}
         statusControls={<GoalStatusIcons goalId={goal._id} />}
         actionMenu={<GoalActionMenuNew onSave={onSave} goalType={GoalType.Weekly} />}
-        onTitleClick={onTitleClick}
+        onTitleSave={handleTitleSave}
       />
 
       <GoalCreatedDate createdAt={goal._creationTime} />
@@ -197,7 +196,6 @@ function WeeklyGoalPopoverContentInner({
             details={goal.details ?? ''}
             onDetailsChange={handleDetailsChange}
             showSeparator={false}
-            onEditClick={onEditClick}
           />
 
           <GoalChildrenSection

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
@@ -9,6 +9,13 @@ vi.mock('@/components/ui/rich-text-editor', () => ({
     const cleanContent = textContent.replace(/[\s\u00A0\u200B\u200C\u200D\uFEFF]/g, '');
     return cleanContent === '';
   },
+  RichTextEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea
+      aria-label="Goal details editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
 }));
 
 vi.mock('@/components/ui/safe-html', () => ({
@@ -24,25 +31,70 @@ vi.mock('@/components/ui/interactive-html', () => ({
 }));
 
 describe('GoalDetailsSection', () => {
-  it('shows empty state for undefined details when onEditClick is provided', () => {
-    const onEditClick = vi.fn();
-    render(
-      <GoalDetailsSection title="Goal" details="" onEditClick={onEditClick} showSeparator={false} />
-    );
-    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
-    expect(onEditClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows empty state for empty HTML details', () => {
+  it('shows empty state for empty details when editable', () => {
+    const onDetailsChange = vi.fn();
     render(
       <GoalDetailsSection
         title="Goal"
-        details="<p></p>"
-        onEditClick={vi.fn()}
+        details=""
+        onDetailsChange={onDetailsChange}
         showSeparator={false}
       />
     );
     expect(screen.getByRole('button', { name: /no details/i })).toBeInTheDocument();
+  });
+
+  it('enters inline editor when clicking empty add button', () => {
+    const onDetailsChange = vi.fn();
+    render(
+      <GoalDetailsSection
+        title="Goal"
+        details=""
+        onDetailsChange={onDetailsChange}
+        showSeparator={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
+    expect(screen.getByRole('textbox', { name: /goal details editor/i })).toBeInTheDocument();
+  });
+
+  it('saves details on Cmd+Enter in editor', () => {
+    const onDetailsChange = vi.fn();
+    render(
+      <GoalDetailsSection
+        title="Goal"
+        details=""
+        onDetailsChange={onDetailsChange}
+        showSeparator={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
+    const editor = screen.getByRole('textbox', { name: /goal details editor/i });
+    fireEvent.change(editor, { target: { value: '<p>New details</p>' } });
+    const container = editor.closest('[class*="rounded-md"]');
+    expect(container).not.toBeNull();
+    fireEvent.keyDown(container as Element, { key: 'Enter', metaKey: true });
+    expect(onDetailsChange).toHaveBeenCalled();
+  });
+
+  it('cancels editing on Escape', () => {
+    const onDetailsChange = vi.fn();
+    render(
+      <GoalDetailsSection
+        title="Goal"
+        details=""
+        onDetailsChange={onDetailsChange}
+        showSeparator={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
+    const editor = screen.getByRole('textbox', { name: /goal details editor/i });
+    expect(editor).toBeInTheDocument();
+    const container = editor.closest('[class*="rounded-md"]');
+    expect(container).not.toBeNull();
+    fireEvent.keyDown(container as Element, { key: 'Escape' });
+    expect(screen.queryByRole('textbox', { name: /goal details editor/i })).not.toBeInTheDocument();
+    expect(onDetailsChange).not.toHaveBeenCalled();
   });
 
   it('renders content when details have text', () => {
@@ -51,7 +103,7 @@ describe('GoalDetailsSection', () => {
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
-  it('returns null when no details and no onEditClick', () => {
+  it('returns null when no details and not editable', () => {
     const { container } = render(
       <GoalDetailsSection title="Goal" details="" showSeparator={false} />
     );

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.test.tsx
@@ -97,6 +97,26 @@ describe('GoalDetailsSection', () => {
     expect(onDetailsChange).not.toHaveBeenCalled();
   });
 
+  it('does not save when Escape is followed by container blur', () => {
+    const onDetailsChange = vi.fn();
+    render(
+      <GoalDetailsSection
+        title="Goal"
+        details=""
+        onDetailsChange={onDetailsChange}
+        showSeparator={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /no details/i }));
+    const editor = screen.getByRole('textbox', { name: /goal details editor/i });
+    fireEvent.change(editor, { target: { value: '<p>New details</p>' } });
+    const container = editor.closest('[class*="rounded-md"]');
+    expect(container).not.toBeNull();
+    fireEvent.keyDown(container as Element, { key: 'Escape' });
+    fireEvent.blur(container as Element);
+    expect(onDetailsChange).not.toHaveBeenCalled();
+  });
+
   it('renders content when details have text', () => {
     render(<GoalDetailsSection title="Goal" details="<p>Hello</p>" showSeparator={false} />);
     expect(screen.queryByRole('button', { name: /no details/i })).not.toBeInTheDocument();

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { GoalDetailsContent } from './GoalDetailsContent';
 
@@ -29,6 +29,7 @@ function GoalDetailsSection({
   const hasDetails = !isHTMLEmpty(details);
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(details);
+  const isCancellingRef = useRef(false);
 
   useEffect(() => {
     if (!isEditing) setDraft(details);
@@ -40,11 +41,16 @@ function GoalDetailsSection({
   }, [details]);
 
   const saveAndClose = useCallback(() => {
+    if (isCancellingRef.current) {
+      isCancellingRef.current = false;
+      return;
+    }
     if (editable && onDetailsChange && draft !== details) onDetailsChange(draft);
     setIsEditing(false);
   }, [editable, onDetailsChange, draft, details]);
 
   const cancel = useCallback(() => {
+    isCancellingRef.current = true;
     setDraft(details);
     setIsEditing(false);
   }, [details]);

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsSection.tsx
@@ -1,6 +1,8 @@
+import { useCallback, useEffect, useState } from 'react';
+
 import { GoalDetailsContent } from './GoalDetailsContent';
 
-import { isHTMLEmpty } from '@/components/ui/rich-text-editor';
+import { isHTMLEmpty, RichTextEditor } from '@/components/ui/rich-text-editor';
 import { Separator } from '@/components/ui/separator';
 
 export interface GoalDetailsSectionProps {
@@ -10,57 +12,88 @@ export interface GoalDetailsSectionProps {
   details: string;
   /** Whether to show the separator above this section */
   showSeparator?: boolean;
-  /** Callback when task list items are checked/unchecked */
+  /** Callback when task list items are checked/unchecked; sets editable mode */
   onDetailsChange?: (newDetails: string) => void;
   /** If true, task list checkboxes are disabled */
   readOnly?: boolean;
-  /** When set, clicking details (or empty state) starts editing */
-  onEditClick?: () => void;
 }
 
-/**
- * Composable section for displaying goal details.
- * Wraps GoalDetailsContent with optional separator.
- * Supports interactive task lists when onDetailsChange is provided.
- *
- * @example
- * ```tsx
- * <GoalDetailsSection
- *   title="My Goal"
- *   details="<p>Some HTML content</p>"
- *   onDetailsChange={(newHtml) => updateGoal(newHtml)}
- * />
- * ```
- */
-// fallow-ignore-next-line complexity
-export function GoalDetailsSection({
+function GoalDetailsSection({
   title,
   details,
   showSeparator = true,
   onDetailsChange,
   readOnly = false,
-  onEditClick,
 }: GoalDetailsSectionProps) {
+  const editable = Boolean(onDetailsChange) && !readOnly;
   const hasDetails = !isHTMLEmpty(details);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(details);
 
-  if (!hasDetails && !onEditClick) return null;
+  useEffect(() => {
+    if (!isEditing) setDraft(details);
+  }, [details, isEditing]);
+
+  const startEdit = useCallback(() => {
+    setDraft(details);
+    setIsEditing(true);
+  }, [details]);
+
+  const saveAndClose = useCallback(() => {
+    if (editable && onDetailsChange && draft !== details) onDetailsChange(draft);
+    setIsEditing(false);
+  }, [editable, onDetailsChange, draft, details]);
+
+  const cancel = useCallback(() => {
+    setDraft(details);
+    setIsEditing(false);
+  }, [details]);
+
+  if (!hasDetails && !editable) return null;
 
   return (
     <>
       {showSeparator && <Separator className="my-2" />}
       <div className="pt-1">
-        {hasDetails ? (
+        {isEditing ? (
+          <div
+            className="min-w-0 rounded-md pt-4 pb-4 px-3 bg-muted/30"
+            onBlur={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                saveAndClose();
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                cancel();
+              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                saveAndClose();
+              }
+            }}
+          >
+            <RichTextEditor
+              value={draft}
+              onChange={setDraft}
+              autoFocus
+              placeholder="Add goal details..."
+              className="text-sm"
+            />
+          </div>
+        ) : hasDetails ? (
           <GoalDetailsContent
             title={title}
             details={details}
             onDetailsChange={onDetailsChange}
             readOnly={readOnly}
-            onEditClick={onEditClick}
+            onEditClick={editable ? startEdit : undefined}
           />
         ) : (
           <button
             type="button"
-            onClick={onEditClick}
+            onClick={startEdit}
             className="w-full text-left text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md px-3 py-4 transition-colors cursor-pointer"
           >
             No details — click to add
@@ -70,3 +103,5 @@ export function GoalDetailsSection({
     </>
   );
 }
+
+export { GoalDetailsSection };

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditContext.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalEditContext.tsx
@@ -1,8 +1,6 @@
 import type { GoalWithDetailsAndChildren } from '@workspace/backend/src/usecase/getWeekDetails';
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 
-import { useGoalContext } from '@/contexts/GoalContext';
-
 /**
  * Context value type for goal editing state management.
  */
@@ -84,22 +82,4 @@ export function GoalEditProvider({ children }: _GoalEditProviderProps) {
   );
 
   return <_GoalEditContext.Provider value={value}>{children}</_GoalEditContext.Provider>;
-}
-
-/**
- * Hook to start editing the current goal from title or details click handlers.
- * Must be used within GoalProvider and GoalEditProvider.
- */
-export function useStartEditingGoal() {
-  const { goal } = useGoalContext();
-  const { startEditing } = useGoalEditContext();
-
-  const handleStartEditing = useCallback(() => {
-    startEditing(goal);
-  }, [startEditing, goal]);
-
-  return {
-    onTitleClick: handleStartEditing,
-    onEditClick: handleStartEditing,
-  };
 }

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
@@ -3,26 +3,71 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { GoalHeader } from './GoalHeader';
 
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
 describe('GoalHeader', () => {
-  it('renders title as a button and calls onTitleClick when clicked', () => {
-    const onTitleClick = vi.fn();
+  it('renders title as a button and enters edit mode on click', () => {
+    const onTitleSave = vi.fn();
 
     render(
       <GoalHeader
         title="My Goal"
         isComplete={false}
         onToggleComplete={vi.fn()}
-        onTitleClick={onTitleClick}
+        onTitleSave={onTitleSave}
       />
     );
 
     const titleButton = screen.getByRole('button', { name: 'My Goal' });
     fireEvent.click(titleButton);
 
-    expect(onTitleClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('My Goal')).toBeInTheDocument();
   });
 
-  it('renders title as heading when onTitleClick is not provided', () => {
+  it('saves on Enter with trimmed value', () => {
+    const onTitleSave = vi.fn();
+
+    render(
+      <GoalHeader
+        title="My Goal"
+        isComplete={false}
+        onToggleComplete={vi.fn()}
+        onTitleSave={onTitleSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'My Goal' }));
+    const input = screen.getByDisplayValue('My Goal');
+    fireEvent.change(input, { target: { value: 'Updated Goal' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onTitleSave).toHaveBeenCalledWith('Updated Goal');
+  });
+
+  it('cancels on Escape and restores title', () => {
+    const onTitleSave = vi.fn();
+
+    render(
+      <GoalHeader
+        title="My Goal"
+        isComplete={false}
+        onToggleComplete={vi.fn()}
+        onTitleSave={onTitleSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'My Goal' }));
+    const input = screen.getByDisplayValue('My Goal');
+    fireEvent.change(input, { target: { value: 'Updated Goal' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onTitleSave).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'My Goal' })).toBeInTheDocument();
+  });
+
+  it('renders title as heading when onTitleSave is not provided', () => {
     render(<GoalHeader title="Static Goal" isComplete={false} />);
 
     expect(screen.getByRole('heading', { name: 'Static Goal' })).toBeInTheDocument();

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.test.tsx
@@ -67,6 +67,27 @@ describe('GoalHeader', () => {
     expect(screen.getByRole('button', { name: 'My Goal' })).toBeInTheDocument();
   });
 
+  it('does not save when Escape is followed by blur', () => {
+    const onTitleSave = vi.fn();
+
+    render(
+      <GoalHeader
+        title="My Goal"
+        isComplete={false}
+        onToggleComplete={vi.fn()}
+        onTitleSave={onTitleSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'My Goal' }));
+    const input = screen.getByDisplayValue('My Goal');
+    fireEvent.change(input, { target: { value: 'Updated Goal' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+
+    expect(onTitleSave).not.toHaveBeenCalled();
+  });
+
   it('renders title as heading when onTitleSave is not provided', () => {
     render(<GoalHeader title="Static Goal" isComplete={false} />);
 

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
@@ -52,6 +52,7 @@ export function GoalHeader({
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isCancellingRef = useRef(false);
 
   useEffect(() => {
     if (!isEditing) setDraft(title);
@@ -65,6 +66,10 @@ export function GoalHeader({
   }, [isEditing]);
 
   const commit = useCallback(() => {
+    if (isCancellingRef.current) {
+      isCancellingRef.current = false;
+      return;
+    }
     const trimmed = draft.trim();
     if (!trimmed) {
       toast({
@@ -79,6 +84,7 @@ export function GoalHeader({
   }, [draft, title, onTitleSave]);
 
   const cancel = useCallback(() => {
+    isCancellingRef.current = true;
     setDraft(title);
     setIsEditing(false);
   }, [title]);

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalHeader.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 
 import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui/use-toast';
 
 export interface GoalHeaderProps {
   /** The goal title */
@@ -17,8 +19,8 @@ export interface GoalHeaderProps {
   actionMenu?: ReactNode;
   /** Title size variant */
   size?: 'default' | 'large';
-  /** When set, title is clickable to start editing */
-  onTitleClick?: () => void;
+  /** When set, title is clickable for inline edit; commits via this callback */
+  onTitleSave?: (title: string) => void;
 }
 
 /**
@@ -44,9 +46,55 @@ export function GoalHeader({
   statusControls,
   actionMenu,
   size = 'default',
-  onTitleClick,
+  onTitleSave,
 }: GoalHeaderProps) {
   const titleClassName = size === 'large' ? 'font-semibold text-xl' : 'font-semibold text-lg';
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isEditing) setDraft(title);
+  }, [title, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const commit = useCallback(() => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      toast({
+        title: 'Error',
+        description: 'Goal title cannot be empty',
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (trimmed !== title) onTitleSave?.(trimmed);
+    setIsEditing(false);
+  }, [draft, title, onTitleSave]);
+
+  const cancel = useCallback(() => {
+    setDraft(title);
+    setIsEditing(false);
+  }, [title]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancel();
+      }
+    },
+    [commit, cancel]
+  );
 
   return (
     <div className="flex items-start justify-between gap-3">
@@ -57,10 +105,19 @@ export function GoalHeader({
           disabled={disableCompletion || !onToggleComplete}
           onCheckedChange={(checked) => onToggleComplete?.(checked === true)}
         />
-        {onTitleClick ? (
+        {isEditing ? (
+          <Input
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={commit}
+            className={`${titleClassName} h-auto border-0 px-0 py-0 shadow-none focus-visible:ring-0`}
+          />
+        ) : onTitleSave ? (
           <button
             type="button"
-            onClick={onTitleClick}
+            onClick={() => setIsEditing(true)}
             className={`${titleClassName} break-words flex-1 leading-tight text-left hover:text-primary transition-colors cursor-pointer`}
           >
             {title}

--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/index.ts
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/index.ts
@@ -23,7 +23,7 @@ export {
 export { GoalDomainDisplay, type GoalDomainDisplayProps } from './GoalDomainDisplay';
 export { GoalDueDateDisplay, type GoalDueDateDisplayProps } from './GoalDueDateDisplay';
 export { GoalInitiativeField } from './GoalInitiativeField';
-export { GoalEditProvider, useGoalEditContext, useStartEditingGoal } from './GoalEditContext';
+export { GoalEditProvider, useGoalEditContext } from './GoalEditContext';
 export { GoalEditModal, type GoalEditModalProps } from './GoalEditModal';
 export { GoalHeader, type GoalHeaderProps } from './GoalHeader';
 export { GoalStatusIndicators, type GoalStatusIndicatorsProps } from './GoalStatusIndicators';

--- a/apps/webapp/src/hooks/useGoalDetailsSave.ts
+++ b/apps/webapp/src/hooks/useGoalDetailsSave.ts
@@ -51,3 +51,25 @@ export function useAdhocGoalDetailsSaveViaHandler(
     [onSave, goal.title, goal.adhoc?.dueDate]
   );
 }
+
+type GoalTitleSaveSnapshot = {
+  details?: string;
+  dueDate?: number;
+  domainId?: Id<'domains'> | null;
+  initiativeId?: Id<'initiatives'> | null;
+  adhoc?: { dueDate?: number };
+};
+
+/** Title-only save via GoalSaveHandler — preserves details/dueDate/domain/initiative. */
+export function useGoalTitleSave(
+  onSave: GoalSaveHandler,
+  goal: GoalTitleSaveSnapshot
+): (title: string) => void {
+  return useCallback(
+    (title: string) => {
+      const dueDate = goal.adhoc?.dueDate ?? goal.dueDate;
+      void onSave(title, goal.details, dueDate, goal.domainId, goal.initiativeId);
+    },
+    [onSave, goal.details, goal.dueDate, goal.adhoc?.dueDate, goal.domainId, goal.initiativeId]
+  );
+}


### PR DESCRIPTION
## Summary

Clicking a goal title or details in detail surfaces (popovers, quick views, page content) now edits **inline** instead of opening `GoalEditModal`. The action-menu "Edit" path still opens `GoalEditModal` for full-field editing (due date, initiative, domain).

## Changes

### Shared atoms
- **GoalHeader**: `onTitleClick` → `onTitleSave`. When set, clicking the title enters inline `Input` edit mode. Enter/blur saves, Escape cancels. Empty title rejected with toast.
- **GoalDetailsSection**: Removed `onEditClick` from public API. Editable inferred from `onDetailsChange` presence. Owns inline `RichTextEditor` with blur/Cmd+Enter save, Escape cancel.
- **GoalEditContext/useStartEditingGoal**: Removed `useStartEditingGoal` (no longer used). `useGoalEditContext().startEditing` remains for action-menu modal.
- **useGoalTitleSave**: New shared hook that preserves details/dueDate/domain/initiative when saving a title-only change.

### Consumer rewires (9 files)
All variant files updated to use `onTitleSave` + remove `onEditClick`:
- `WeeklyGoalPopover.tsx`
- `QuarterlyGoalPopover.tsx`
- `DailyGoalPopover.tsx`
- `AdhocGoalPopover.tsx`
- `StandardGoalPopoverContent.tsx`
- `AdhocGoalPopoverContent.tsx`
- `WeeklyGoalPageContent.tsx`
- `GoalQuickViewModal.tsx`
- `AdhocGoalQuickViewModal.tsx`

## Test Plan

1. **Title inline edit**: Click title in any goal detail popover → inline input appears. Enter saves, Escape cancels. Empty trimmed title shows destructive toast.
2. **Details inline edit**: Click details (or "No details — click to add") → `RichTextEditor` opens. Blur or Cmd+Enter saves. Escape cancels without saving.
3. **Task list checkboxes**: Clicking a checkbox toggles via `InteractiveHTML` without entering edit mode (preserves `isInteractiveClickTarget`).
4. **Action menu Edit**: "Edit" in action menu still opens `GoalEditModal` with full fields.
5. **Expand-to-full-view**: Works in view mode; hidden while editing.
6. **Typecheck + tests**: `pnpm typecheck` passes, `pnpm test` passes (251 tests, 34 files).