### PR TITLE
fix(ui): readable contrast for markdown code blocks

### DIFF
--- a/apps/webapp/src/components/ui/rich-text-editor.module.css
+++ b/apps/webapp/src/components/ui/rich-text-editor.module.css
@@ -401,7 +401,7 @@
    CODE (Inline & Blocks)
    ========================================================================== */
 
-/* Inline code */
+/* Inline code — force readable contrast on muted backgrounds (prose defaults are grey-on-grey) */
 .prose :global(code) {
   padding: 0.125em 0.35em !important;
   border-radius: 0.25rem !important;
@@ -410,6 +410,8 @@
   word-break: break-word !important;
   overflow-wrap: anywhere !important;
   max-width: 100% !important;
+  color: var(--foreground) !important;
+  background-color: var(--muted) !important;
 }
 
 /* Inline code only — pasted styled content can force block/nowrap and blow out containers */
@@ -420,7 +422,7 @@
   -webkit-box-decoration-break: clone !important;
 }
 
-/* Code blocks */
+/* Code blocks — same contrast fix for fenced blocks in view + edit modes */
 .prose :global(pre) {
   margin-top: 0.75em !important;
   margin-bottom: 0.75em !important;
@@ -431,9 +433,11 @@
   overflow-x: auto !important;
   font-size: 0.85em !important;
   line-height: 1.5 !important;
+  color: var(--foreground) !important;
+  background-color: var(--muted) !important;
 }
 
-/* Code inside pre - reset inline styles */
+/* Code inside pre - reset inline styles; inherit readable pre color */
 .prose :global(pre code) {
   display: block !important;
   padding: 0 !important;

--- a/apps/webapp/src/components/ui/rich-text-editor.tsx
+++ b/apps/webapp/src/components/ui/rich-text-editor.tsx
@@ -354,12 +354,12 @@ export function RichTextEditor({
         },
         code: {
           HTMLAttributes: {
-            class: 'rounded-md bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm',
+            class: 'rounded-md bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm text-foreground',
           },
         },
         codeBlock: {
           HTMLAttributes: {
-            class: 'rounded-md bg-muted p-4 font-mono text-sm',
+            class: 'rounded-md bg-muted p-4 font-mono text-sm text-foreground',
           },
         },
         blockquote: {


### PR DESCRIPTION
## Summary
- Code blocks and inline code in rich-text/markdown render were grey text on a grey (`muted`) background, making them hard or impossible to read.
- Force `foreground` text color (and explicit `muted` background) in prose CSS so view mode and existing HTML stay readable.
- Align TipTap `code` / `codeBlock` HTML attributes with the MDX pattern (`text-foreground` on `bg-muted`).

## Test plan
- [ ] Open a goal with fenced ``` code blocks in details (light + dark mode)
- [ ] Confirm code text is clearly readable against the code background
- [ ] Confirm inline `code` is also readable
- [ ] Confirm edit mode (rich text editor) shows the same readable contrast
- [ ] Spot-check that non-code markdown (paragraphs, lists, links) is unchanged


Made with [Cursor](https://cursor.com)