### PR TITLE
fix(rich-text-editor): remove duplicate TipTap underline extension

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -44,7 +44,6 @@
     "@tiptap/extension-placeholder": "^3.13.0",
     "@tiptap/extension-task-item": "^3.13.0",
     "@tiptap/extension-task-list": "^3.13.0",
-    "@tiptap/extension-underline": "^3.13.0",
     "@tiptap/pm": "^3.13.0",
     "@tiptap/react": "^3.13.0",
     "@tiptap/starter-kit": "^3.13.0",

--- a/apps/webapp/src/components/ui/rich-text-editor.tsx
+++ b/apps/webapp/src/components/ui/rich-text-editor.tsx
@@ -2,7 +2,6 @@ import { Extension } from '@tiptap/core';
 import Placeholder from '@tiptap/extension-placeholder';
 import TaskItem from '@tiptap/extension-task-item';
 import TaskList from '@tiptap/extension-task-list';
-import Underline from '@tiptap/extension-underline';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 import { EditorContent, useEditor } from '@tiptap/react';
@@ -387,7 +386,6 @@ export function RichTextEditor({
           class: 'task-item flex gap-2',
         },
       }),
-      Underline,
       Placeholder.configure({
         placeholder,
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,6 @@ importers:
       '@tiptap/extension-task-list':
         specifier: ^3.13.0
         version: 3.19.0(@tiptap/extension-list@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))
-      '@tiptap/extension-underline':
-        specifier: ^3.13.0
-        version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))
       '@tiptap/pm':
         specifier: ^3.13.0
         version: 3.19.0


### PR DESCRIPTION
## Summary
- Removes the explicit `@tiptap/extension-underline` registration from `RichTextEditor`
- TipTap StarterKit v3 includes `Underline` by default, so the duplicate triggered a browser console warning: `Duplicate extension names found: ['underline']`
- Drops the now-unused direct dependency on `@tiptap/extension-underline`

## Test plan
- [x] `pnpm --filter @workspace/webapp typecheck`
- [x] `pnpm --filter @workspace/webapp test`
- [ ] Open a goal details inline editor and confirm no TipTap underline warning in browser console
- [ ] Confirm underline formatting still works via StarterKit

Made with [Cursor](https://cursor.com)