### PR TITLE
fix(goal-details): remove redundant expand-to-full-view button

### DIFF
--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -1,9 +1,3 @@
-import { Maximize2 } from 'lucide-react';
-import { useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { FixedSizeDialog, FixedSizeDialogContent } from '@/components/ui/fixed-size-dialog';
 import { InteractiveHTML } from '@/components/ui/interactive-html';
 import { SafeHTML } from '@/components/ui/safe-html';
 import { isInteractiveClickTarget } from '@/lib/dom/isInteractiveClickTarget';
@@ -13,7 +7,7 @@ import { cn } from '@/lib/utils';
  * Props for the GoalDetailsContent component.
  */
 export interface GoalDetailsContentProps {
-  /** The goal title (displayed in full view dialog header) */
+  /** The goal title (displayed when showTitle is true) */
   title: string;
   /** HTML content to display as goal details */
   details: string;
@@ -21,8 +15,6 @@ export interface GoalDetailsContentProps {
   className?: string;
   /** Whether to show the title above the content */
   showTitle?: boolean;
-  /** Whether to show the full-view expand action above the content */
-  showExpandAction?: boolean;
   /** Callback when task list items are checked/unchecked */
   onDetailsChange?: (newDetails: string) => void;
   /** If true, task list checkboxes are disabled */
@@ -32,8 +24,7 @@ export interface GoalDetailsContentProps {
 }
 
 /**
- * Displays goal details content with an expandable full view dialog.
- * Shows HTML content in a scrollable container with an always-visible expand action.
+ * Displays goal details content in a scrollable container.
  * Supports interactive task lists with checkable items.
  *
  * @example
@@ -46,18 +37,15 @@ export interface GoalDetailsContentProps {
  * />
  * ```
  */
-// fallow-ignore-next-line complexity
 export function GoalDetailsContent({
   title,
   details,
   className,
   showTitle = false,
-  showExpandAction = true,
   onDetailsChange,
   readOnly = false,
   onEditClick,
 }: GoalDetailsContentProps) {
-  const [isFullViewOpen, setIsFullViewOpen] = useState(false);
   const hasInteractiveFeatures = onDetailsChange && !readOnly;
 
   const handleDetailsClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -66,90 +54,47 @@ export function GoalDetailsContent({
   };
 
   return (
-    <>
-      <div className="space-y-3">
-        {(showTitle || showExpandAction) && (
-          <div className="flex items-center justify-between gap-3 border-b-2 border-border px-4 py-3">
-            {showTitle ? (
-              <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
-            ) : (
-              <div className="flex-1" />
-            )}
-            {showExpandAction && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 text-xs uppercase tracking-wider font-bold"
-                onClick={() => setIsFullViewOpen(true)}
-                title="Expand to full view"
-                aria-label="Expand goal details"
-              >
-                <Maximize2 className="h-3.5 w-3.5 mr-1" />
-                Expand
-              </Button>
-            )}
-          </div>
-        )}
-
-        <div
-          onClick={onEditClick ? handleDetailsClick : undefined}
-          className={cn(
-            'min-w-0 overflow-x-hidden overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30',
-            onEditClick && 'cursor-pointer hover:bg-muted/50 transition-colors',
-            className
-          )}
-          role={onEditClick ? 'button' : undefined}
-          tabIndex={onEditClick ? 0 : undefined}
-          onKeyDown={
-            onEditClick
-              ? (e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    onEditClick();
-                  }
-                }
-              : undefined
-          }
-        >
-          {hasInteractiveFeatures ? (
-            <InteractiveHTML
-              html={details}
-              className="text-sm prose prose-sm dark:prose-invert max-w-none"
-              onContentChange={onDetailsChange}
-              readOnly={readOnly}
-            />
-          ) : (
-            <SafeHTML
-              html={details}
-              className="text-sm prose prose-sm dark:prose-invert max-w-none"
-            />
-          )}
+    <div className="space-y-3">
+      {showTitle && (
+        <div className="flex items-center justify-between gap-3 border-b-2 border-border px-4 py-3">
+          <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
         </div>
-      </div>
+      )}
 
-      {/* Full view dialog */}
-      <Dialog open={isFullViewOpen} onOpenChange={(open) => !open && setIsFullViewOpen(false)}>
-        <FixedSizeDialog>
-          <DialogHeader>
-            <DialogTitle className="text-xl font-semibold break-words">{title}</DialogTitle>
-          </DialogHeader>
-          <FixedSizeDialogContent>
-            {hasInteractiveFeatures ? (
-              <InteractiveHTML
-                html={details}
-                className="text-sm prose prose-sm dark:prose-invert max-w-none"
-                onContentChange={onDetailsChange}
-                readOnly={readOnly}
-              />
-            ) : (
-              <SafeHTML
-                html={details}
-                className="text-sm prose prose-sm dark:prose-invert max-w-none"
-              />
-            )}
-          </FixedSizeDialogContent>
-        </FixedSizeDialog>
-      </Dialog>
-    </>
+      <div
+        onClick={onEditClick ? handleDetailsClick : undefined}
+        className={cn(
+          'min-w-0 overflow-x-hidden overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30',
+          onEditClick && 'cursor-pointer hover:bg-muted/50 transition-colors',
+          className
+        )}
+        role={onEditClick ? 'button' : undefined}
+        tabIndex={onEditClick ? 0 : undefined}
+        onKeyDown={
+          onEditClick
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onEditClick();
+                }
+              }
+            : undefined
+        }
+      >
+        {hasInteractiveFeatures ? (
+          <InteractiveHTML
+            html={details}
+            className="text-sm prose prose-sm dark:prose-invert max-w-none"
+            onContentChange={onDetailsChange}
+            readOnly={readOnly}
+          />
+        ) : (
+          <SafeHTML
+            html={details}
+            className="text-sm prose prose-sm dark:prose-invert max-w-none"
+          />
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the "Expand" button and full-view dialog from `GoalDetailsContent`
- The expand action duplicated navigation already available in the goal details popover/modal

## Test plan
- [x] Goal details popover tests pass locally
- [ ] Open an adhoc goal details popover and confirm the Expand button is gone
- [ ] Confirm goal details content still renders and inline/task-list interactions still work

Made with [Cursor](https://cursor.com)