### PR TITLE
fix(goal-details): remove redundant expand-to-full-view button

### DIFF
--- a/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
+++ b/apps/webapp/src/components/molecules/goal-details-popover/view/components/GoalDetailsContent.tsx
@@ -1,9 +1,3 @@
-import { Maximize2 } from 'lucide-react';
-import { useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { FixedSizeDialog, FixedSizeDialogContent } from '@/components/ui/fixed-size-dialog';
 import { InteractiveHTML } from '@/components/ui/interactive-html';
 import { SafeHTML } from '@/components/ui/safe-html';
 import { cn } from '@/lib/utils';
@@ -12,7 +6,7 @@ import { cn } from '@/lib/utils';
  * Props for the GoalDetailsContent component.
  */
 export interface GoalDetailsContentProps {
-  /** The goal title (displayed in full view dialog header) */
+  /** The goal title (displayed when showTitle is true) */
   title: string;
   /** HTML content to display as goal details */
   details: string;
@@ -27,8 +21,7 @@ export interface GoalDetailsContentProps {
 }
 
 /**
- * Displays goal details content with an expandable full view dialog.
- * Shows HTML content in a scrollable container with an expand button on hover.
+ * Displays goal details content in a scrollable container.
  * Supports interactive task lists with checkable items.
  *
  * @example
@@ -49,85 +42,36 @@ export function GoalDetailsContent({
   onDetailsChange,
   readOnly = false,
 }: GoalDetailsContentProps) {
-  const [isFullViewOpen, setIsFullViewOpen] = useState(false);
   const hasInteractiveFeatures = onDetailsChange && !readOnly;
 
   return (
-    <>
-      <div className="space-y-3">
-        {showTitle && (
-          <div className="flex items-center gap-2">
-            <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
-          </div>
-        )}
-
-        <div
-          className={cn(
-            'max-h-[300px] overflow-y-auto rounded-md pt-4 pb-4 px-3 relative group bg-muted/30',
-            className
-          )}
-        >
-          {hasInteractiveFeatures ? (
-            <InteractiveHTML
-              html={details}
-              className="text-sm prose prose-sm dark:prose-invert max-w-none"
-              onContentChange={onDetailsChange}
-              readOnly={readOnly}
-            />
-          ) : (
-            <SafeHTML
-              html={details}
-              className="text-sm prose prose-sm dark:prose-invert max-w-none"
-            />
-          )}
-
-          {/* Absolutely positioned expand button */}
-          <div className="absolute top-0 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none group-hover:pointer-events-auto">
-            <_ExpandButton onClick={() => setIsFullViewOpen(true)} />
-          </div>
+    <div className="space-y-3">
+      {showTitle && (
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold text-base break-words flex-1">{title}</h3>
         </div>
+      )}
+
+      <div
+        className={cn(
+          'max-h-[300px] overflow-y-auto rounded-md pt-4 pb-4 px-3 bg-muted/30',
+          className
+        )}
+      >
+        {hasInteractiveFeatures ? (
+          <InteractiveHTML
+            html={details}
+            className="text-sm prose prose-sm dark:prose-invert max-w-none"
+            onContentChange={onDetailsChange}
+            readOnly={readOnly}
+          />
+        ) : (
+          <SafeHTML
+            html={details}
+            className="text-sm prose prose-sm dark:prose-invert max-w-none"
+          />
+        )}
       </div>
-
-      {/* Full view dialog */}
-      <Dialog open={isFullViewOpen} onOpenChange={(open) => !open && setIsFullViewOpen(false)}>
-        <FixedSizeDialog>
-          <DialogHeader>
-            <DialogTitle className="text-xl font-semibold break-words">{title}</DialogTitle>
-          </DialogHeader>
-          <FixedSizeDialogContent>
-            {hasInteractiveFeatures ? (
-              <InteractiveHTML
-                html={details}
-                className="text-sm prose prose-sm dark:prose-invert max-w-none"
-                onContentChange={onDetailsChange}
-                readOnly={readOnly}
-              />
-            ) : (
-              <SafeHTML
-                html={details}
-                className="text-sm prose prose-sm dark:prose-invert max-w-none"
-              />
-            )}
-          </FixedSizeDialogContent>
-        </FixedSizeDialog>
-      </Dialog>
-    </>
-  );
-}
-
-/**
- * Internal expand button component for triggering full view dialog.
- */
-function _ExpandButton({ onClick }: { onClick: () => void }) {
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-5 w-5 text-muted-foreground hover:text-foreground flex-shrink-0 rounded-full bg-background/80 backdrop-blur-sm shadow-sm"
-      onClick={onClick}
-      title="Expand to full view"
-    >
-      <Maximize2 className="h-3 w-3" />
-    </Button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Removes the redundant "Expand to full view" button and full-view dialog from goal details on the release branch.

Cherry-picked from #91 with release-appropriate conflict resolution (expand UI removal only; no master-only inline-edit changes).

## Test plan
- [ ] Open goal details popover and confirm Expand button is gone
- [ ] Confirm task-list checkboxes still work

Made with [Cursor](https://cursor.com)