### PR TITLE
feat(initiatives): auto color-code initiatives from title

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeBadge.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeBadge.tsx
@@ -1,19 +1,38 @@
+'use client';
+
+import { getDomainPillColors } from '@/components/atoms/DomainPill/lib/colors';
+import { getInitiativeColorFromTitle } from '@/lib/initiative/initiative-color';
 import { cn } from '@/lib/utils';
+import { useIsDarkMode } from '@/modules/theme/ThemeProvider';
 
 interface InitiativeBadgeProps {
   title: string;
   className?: string;
+  /** When true, uses muted styling instead of title-based color. */
+  muted?: boolean;
 }
 
-/** Compact pill showing initiative title on goal rows. */
-export function InitiativeBadge({ title, className }: InitiativeBadgeProps) {
+/** Compact pill showing initiative title on goal rows, color-coded by title. */
+export function InitiativeBadge({ title, className, muted = false }: InitiativeBadgeProps) {
+  const isDarkMode = useIsDarkMode();
+  const initiativeColor = getInitiativeColorFromTitle(title);
+  const colors = getDomainPillColors(initiativeColor, isDarkMode);
+
   return (
     <span
       className={cn(
         'inline-flex items-center whitespace-nowrap px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider',
-        'bg-primary/10 text-primary',
+        muted && 'bg-muted text-muted-foreground',
         className
       )}
+      style={
+        muted
+          ? undefined
+          : {
+              color: colors.foreground,
+              backgroundColor: colors.background,
+            }
+      }
       title={title}
     >
       {title}

--- a/apps/webapp/src/components/atoms/InitiativeBadgeForGoal.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeBadgeForGoal.tsx
@@ -27,9 +27,6 @@ export function InitiativeBadgeForGoal({
   const title = titleMap.get(initiativeId);
   if (!title) return null;
   return (
-    <InitiativeBadge
-      title={title}
-      className={cn('flex-shrink-0', isComplete && 'bg-muted text-muted-foreground', className)}
-    />
+    <InitiativeBadge title={title} muted={isComplete} className={cn('flex-shrink-0', className)} />
   );
 }

--- a/apps/webapp/src/components/atoms/InitiativeListItemMeta.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeListItemMeta.tsx
@@ -1,6 +1,7 @@
 import type { Doc } from '@workspace/backend/convex/_generated/dataModel';
 
 import { formatInitiativeDateRange, getInitiativeDateStatus } from '@/lib/date/initiative-dates';
+import { getInitiativeColorFromTitle } from '@/lib/initiative/initiative-color';
 import { initiativeStatusBadge } from '@/lib/initiative/initiative-status-badge';
 import { cn } from '@/lib/utils';
 
@@ -11,9 +12,15 @@ type InitiativeListItemMetaProps = {
 export function InitiativeListItemMeta({ initiative }: InitiativeListItemMetaProps) {
   const status = getInitiativeDateStatus(initiative.startDate, initiative.endDate);
   const badge = initiativeStatusBadge[status];
+  const initiativeColor = getInitiativeColorFromTitle(initiative.title);
 
   return (
     <span className="flex items-center gap-2 min-w-0 flex-1">
+      <span
+        className="flex-shrink-0 w-2 h-2 rounded-full"
+        style={{ backgroundColor: initiativeColor }}
+        aria-hidden
+      />
       <span className="truncate">{initiative.title}</span>
       <span
         className={cn(

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
@@ -65,10 +65,7 @@ export function FocusedGoalListItem({
           {title}
         </button>
         {initiativeTitle && (
-          <InitiativeBadge
-            title={initiativeTitle}
-            className={cn('flex-shrink-0', isComplete && 'bg-muted text-muted-foreground')}
-          />
+          <InitiativeBadge title={initiativeTitle} muted={isComplete} className="flex-shrink-0" />
         )}
       </li>
 

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedInitiativesSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedInitiativesSection.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/molecules/focus/InitiativeFormDialog';
 import { InitiativesBrowseDialog } from '@/components/molecules/focus/InitiativesBrowseDialog';
 import { formatInitiativeDateRange, getInitiativeDateStatus } from '@/lib/date/initiative-dates';
+import { getInitiativeColorFromTitle } from '@/lib/initiative/initiative-color';
 import { filterInitiativesForFocusView } from '@/lib/initiative/initiative-focus-filters';
 import {
   initiativeStatusBadge,
@@ -52,17 +53,25 @@ function InitiativeListRow({
   const status = getInitiativeDateStatus(initiative.startDate, initiative.endDate);
   const badge = initiativeStatusBadge[status];
   const goalCountLabel = counts ? formatGoalCountLabel(counts) : null;
+  const initiativeColor = getInitiativeColorFromTitle(initiative.title);
 
   return (
     <li>
       <div className="flex items-start gap-1 rounded-md hover:bg-accent/50 transition-colors">
         <button type="button" onClick={onView} className="flex-1 min-w-0 text-left px-2 py-2">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{initiative.title}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {formatInitiativeDateRange(initiative.startDate, initiative.endDate)}
-              {goalCountLabel && <span>{` · ${goalCountLabel}`}</span>}
-            </p>
+          <div className="min-w-0 flex items-start gap-2">
+            <span
+              className="mt-1.5 flex-shrink-0 w-2 h-2 rounded-full"
+              style={{ backgroundColor: initiativeColor }}
+              aria-hidden
+            />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">{initiative.title}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {formatInitiativeDateRange(initiative.startDate, initiative.endDate)}
+                {goalCountLabel && <span>{` · ${goalCountLabel}`}</span>}
+              </p>
+            </div>
           </div>
         </button>
         <span

--- a/apps/webapp/src/lib/initiative/initiative-color.test.ts
+++ b/apps/webapp/src/lib/initiative/initiative-color.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { getInitiativeColorFromTitle } from './initiative-color';
+
+const PALETTE_SIZE = 12;
+
+const PALETTE_COLORS = new Set([
+  '#FF3B30',
+  '#FF9500',
+  '#FFCC00',
+  '#34C759',
+  '#00C7BE',
+  '#30B0C7',
+  '#32ADE6',
+  '#007AFF',
+  '#5856D6',
+  '#AF52DE',
+  '#FF2D55',
+  '#A2845E',
+]);
+
+describe('getInitiativeColorFromTitle', () => {
+  it('returns a palette color for non-empty titles', () => {
+    const color = getInitiativeColorFromTitle('Launch Q3');
+    expect(PALETTE_COLORS).toContain(color);
+  });
+
+  it('is stable for the same title', () => {
+    expect(getInitiativeColorFromTitle('Health')).toBe(getInitiativeColorFromTitle('Health'));
+  });
+
+  it('is case and whitespace insensitive', () => {
+    expect(getInitiativeColorFromTitle('Health')).toBe(getInitiativeColorFromTitle('  HEALTH  '));
+  });
+
+  it('assigns different colors to clearly distinct titles', () => {
+    expect(getInitiativeColorFromTitle('Launch Q3')).not.toBe(
+      getInitiativeColorFromTitle('Health & Fitness')
+    );
+  });
+
+  it('distributes colors across the palette for varied titles', () => {
+    const titles = Array.from({ length: 24 }, (_, i) => `Initiative ${i + 1}`);
+    const colors = new Set(titles.map(getInitiativeColorFromTitle));
+    expect(colors.size).toBeGreaterThan(1);
+    expect(colors.size).toBeLessThanOrEqual(PALETTE_SIZE);
+  });
+
+  it('falls back to first palette color for empty titles', () => {
+    expect(getInitiativeColorFromTitle('   ')).toBe('#FF3B30');
+  });
+});

--- a/apps/webapp/src/lib/initiative/initiative-color.ts
+++ b/apps/webapp/src/lib/initiative/initiative-color.ts
@@ -1,0 +1,42 @@
+/**
+ * Curated initiative palette — distinct hues with sufficient contrast on light/dark UI.
+ * Aligned with domain color presets; gray omitted to maximize visual separation.
+ */
+const INITIATIVE_COLOR_PALETTE = [
+  '#FF3B30', // Red
+  '#FF9500', // Orange
+  '#FFCC00', // Yellow
+  '#34C759', // Green
+  '#00C7BE', // Mint
+  '#30B0C7', // Teal
+  '#32ADE6', // Cyan
+  '#007AFF', // Blue
+  '#5856D6', // Indigo
+  '#AF52DE', // Purple
+  '#FF2D55', // Pink
+  '#A2845E', // Brown
+] as const;
+
+function normalizeInitiativeTitleForColor(title: string): string {
+  return title.trim().toLowerCase();
+}
+
+/** FNV-1a 32-bit hash — fast, deterministic, good distribution for short strings. */
+function hashStringToIndex(input: string, modulo: number): number {
+  let hash = 2_166_136_261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return (hash >>> 0) % modulo;
+}
+
+/** Returns a stable hex color for the given initiative title. */
+export function getInitiativeColorFromTitle(title: string): string {
+  const normalized = normalizeInitiativeTitleForColor(title);
+  if (!normalized) {
+    return INITIATIVE_COLOR_PALETTE[0];
+  }
+  const index = hashStringToIndex(normalized, INITIATIVE_COLOR_PALETTE.length);
+  return INITIATIVE_COLOR_PALETTE[index];
+}


### PR DESCRIPTION
## Summary
Initiatives are now automatically color-coded from their title using a curated accessible palette. Colors are stable (same title → same color), case/whitespace insensitive, and reuse existing domain pill contrast logic for light/dark mode.

## Changes
- Add `getInitiativeColorFromTitle()` with FNV-1a hash into a 12-color palette (domain preset hues, gray excluded)
- Update `InitiativeBadge` to render title-derived foreground/background colors
- Add color dots in initiative list rows (`InitiativeListItemMeta`, Focus view initiatives section)
- Completed goals still use muted badge styling

## Test plan
- [ ] Open Focus view — initiatives list shows distinct color dots per title
- [ ] Tag goals with different initiatives — badges show different colors on goal rows
- [ ] Same initiative title always shows the same color after reload
- [ ] Toggle dark mode — badge text/background remain readable
- [ ] Completed goals show muted initiative badges (no title color)

Made with [Cursor](https://cursor.com)