### PR TITLE
feat(initiatives): sequential unique color allocation with 30+ palette

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeBadge.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeBadge.tsx
@@ -1,19 +1,37 @@
+'use client';
+
+import { getDomainPillColors } from '@/components/atoms/DomainPill/lib/colors';
 import { cn } from '@/lib/utils';
+import { useIsDarkMode } from '@/modules/theme/ThemeProvider';
 
 interface InitiativeBadgeProps {
   title: string;
+  color: string;
   className?: string;
+  /** When true, uses muted styling instead of color-based styling. */
+  muted?: boolean;
 }
 
-/** Compact pill showing initiative title on goal rows. */
-export function InitiativeBadge({ title, className }: InitiativeBadgeProps) {
+/** Compact pill showing initiative title on goal rows, color-coded by sequential palette. */
+export function InitiativeBadge({ title, color, className, muted = false }: InitiativeBadgeProps) {
+  const isDarkMode = useIsDarkMode();
+  const colors = getDomainPillColors(color, isDarkMode);
+
   return (
     <span
       className={cn(
         'inline-flex items-center whitespace-nowrap px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider',
-        'bg-primary/10 text-primary',
+        muted && 'bg-muted text-muted-foreground',
         className
       )}
+      style={
+        muted
+          ? undefined
+          : {
+              color: colors.foreground,
+              backgroundColor: colors.background,
+            }
+      }
       title={title}
     >
       {title}

--- a/apps/webapp/src/components/atoms/InitiativeBadgeForGoal.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeBadgeForGoal.tsx
@@ -4,7 +4,9 @@ import type { Id } from '@workspace/backend/convex/_generated/dataModel';
 
 import { InitiativeBadge } from '@/components/atoms/InitiativeBadge';
 import { useInitiatives } from '@/hooks/useInitiatives';
+import { useInitiativeColorMap } from '@/hooks/useInitiativeColorMap';
 import { useInitiativeTitleMap } from '@/hooks/useInitiativeTitleMap';
+import { getInitiativeColorFromMap } from '@/lib/initiative/initiative-color';
 import { cn } from '@/lib/utils';
 import { useSession } from '@/modules/auth/useSession';
 
@@ -14,7 +16,7 @@ interface InitiativeBadgeForGoalProps {
   className?: string;
 }
 
-/** Resolves initiative title and renders badge; null if no initiative or title. */
+/** Resolves initiative title and color, then renders badge; null if no initiative or title. */
 export function InitiativeBadgeForGoal({
   initiativeId,
   isComplete = false,
@@ -23,13 +25,17 @@ export function InitiativeBadgeForGoal({
   const { sessionId } = useSession();
   const { initiatives } = useInitiatives(sessionId);
   const titleMap = useInitiativeTitleMap(initiatives);
+  const colorMap = useInitiativeColorMap(initiatives);
   if (!initiativeId) return null;
   const title = titleMap.get(initiativeId);
   if (!title) return null;
+  const color = getInitiativeColorFromMap(initiativeId, colorMap);
   return (
     <InitiativeBadge
       title={title}
-      className={cn('flex-shrink-0', isComplete && 'bg-muted text-muted-foreground', className)}
+      color={color}
+      muted={isComplete}
+      className={cn('flex-shrink-0', className)}
     />
   );
 }

--- a/apps/webapp/src/components/atoms/InitiativeListItemMeta.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeListItemMeta.tsx
@@ -6,14 +6,20 @@ import { cn } from '@/lib/utils';
 
 type InitiativeListItemMetaProps = {
   initiative: Pick<Doc<'initiatives'>, 'startDate' | 'endDate' | 'title'>;
+  color: string;
 };
 
-export function InitiativeListItemMeta({ initiative }: InitiativeListItemMetaProps) {
+export function InitiativeListItemMeta({ initiative, color }: InitiativeListItemMetaProps) {
   const status = getInitiativeDateStatus(initiative.startDate, initiative.endDate);
   const badge = initiativeStatusBadge[status];
 
   return (
     <span className="flex items-center gap-2 min-w-0 flex-1">
+      <span
+        className="flex-shrink-0 w-2 h-2 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
       <span className="truncate">{initiative.title}</span>
       <span
         className={cn(

--- a/apps/webapp/src/components/atoms/InitiativeSelector.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.tsx
@@ -16,6 +16,10 @@ import {
 } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { formatInitiativeDateRange } from '@/lib/date/initiative-dates';
+import {
+  buildInitiativeColorMap,
+  getInitiativeColorFromMap,
+} from '@/lib/initiative/initiative-color';
 import { sortInitiativesByStatusAndDate } from '@/lib/initiative/initiative-status-badge';
 import { cn } from '@/lib/utils';
 
@@ -46,6 +50,8 @@ export function InitiativeSelector({
     () => sortInitiativesByStatusAndDate(initiatives),
     [initiatives]
   );
+
+  const colorMap = useMemo(() => buildInitiativeColorMap(initiatives), [initiatives]);
 
   const selectedInitiative =
     selectedInitiativeId == null
@@ -110,7 +116,10 @@ export function InitiativeSelector({
                       <Check
                         className={cn('mr-2 h-4 w-4', isSelected ? 'opacity-100' : 'opacity-0')}
                       />
-                      <InitiativeListItemMeta initiative={initiative} />
+                      <InitiativeListItemMeta
+                        initiative={initiative}
+                        color={getInitiativeColorFromMap(initiative._id, colorMap)}
+                      />
                     </CommandItem>
                   );
                 })}

--- a/apps/webapp/src/components/molecules/focus/InitiativesBrowseDialog.tsx
+++ b/apps/webapp/src/components/molecules/focus/InitiativesBrowseDialog.tsx
@@ -13,6 +13,10 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
+import {
+  buildInitiativeColorMap,
+  getInitiativeColorFromMap,
+} from '@/lib/initiative/initiative-color';
 import { getInitiativesForBrowse } from '@/lib/initiative/initiative-focus-filters';
 import { sortInitiativesByStatusAndDate } from '@/lib/initiative/initiative-status-badge';
 
@@ -35,6 +39,8 @@ export function InitiativesBrowseDialog({
     () => sortInitiativesByStatusAndDate(getInitiativesForBrowse(initiatives, query)),
     [initiatives, query]
   );
+
+  const colorMap = useMemo(() => buildInitiativeColorMap(initiatives), [initiatives]);
 
   const handleSelect = (initiative: Doc<'initiatives'>) => {
     onSelectInitiative(initiative);
@@ -65,7 +71,10 @@ export function InitiativesBrowseDialog({
               onSelect={() => handleSelect(initiative)}
             >
               <Flag className="mr-2 h-4 w-4 text-muted-foreground flex-shrink-0" />
-              <InitiativeListItemMeta initiative={initiative} />
+              <InitiativeListItemMeta
+                initiative={initiative}
+                color={getInitiativeColorFromMap(initiative._id, colorMap)}
+              />
             </CommandItem>
           ))}
         </CommandGroup>

--- a/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
+++ b/apps/webapp/src/components/organisms/focus/FocusModeFocusedView.tsx
@@ -36,6 +36,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { RichTextEditor } from '@/components/ui/rich-text-editor';
 import { useInitiatives } from '@/hooks/useInitiatives';
+import { useInitiativeColorMap } from '@/hooks/useInitiativeColorMap';
 import { useInitiativeTitleMap } from '@/hooks/useInitiativeTitleMap';
 import { useScratchpad } from '@/hooks/useScratchpad';
 import { useWeekData, WeekProvider } from '@/hooks/useWeek';
@@ -68,6 +69,7 @@ export function FocusModeFocusedView() {
     isDeleting,
   } = useInitiatives(sessionId);
   const initiativeTitleMap = useInitiativeTitleMap(initiatives);
+  const initiativeColorMap = useInitiativeColorMap(initiatives);
 
   // ── History dialog ─────────────────────────────────────────────────────
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
@@ -299,6 +301,7 @@ export function FocusModeFocusedView() {
               goals={filteredUrgent}
               onToggleComplete={handleUrgentCompleteChange}
               initiativeTitleMap={initiativeTitleMap}
+              initiativeColorMap={initiativeColorMap}
             />
 
             <FocusedInitiativesSection
@@ -320,6 +323,7 @@ export function FocusModeFocusedView() {
               onToggleComplete={handleNormalGoalCompleteChange}
               onAddGoal={() => setIsCreateQuarterlyGoalOpen(true)}
               initiativeTitleMap={initiativeTitleMap}
+              initiativeColorMap={initiativeColorMap}
             />
 
             <CreateQuarterlyGoalDialog
@@ -334,6 +338,7 @@ export function FocusModeFocusedView() {
               goals={filteredAdhoc}
               onToggleComplete={handleAdhocCompleteChange}
               initiativeTitleMap={initiativeTitleMap}
+              initiativeColorMap={initiativeColorMap}
             />
 
             {/* Inline add task */}

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedAdhocGoalsSection.tsx
@@ -11,12 +11,14 @@ interface FocusedAdhocGoalsSectionProps {
   goals: FocusedGoalItem[] | undefined;
   onToggleComplete: (goalId: FocusedGoalItem['_id'], isComplete: boolean) => void;
   initiativeTitleMap: Map<Id<'initiatives'>, string>;
+  initiativeColorMap: Map<Id<'initiatives'>, string>;
 }
 
 export function FocusedAdhocGoalsSection({
   goals,
   onToggleComplete,
   initiativeTitleMap,
+  initiativeColorMap,
 }: FocusedAdhocGoalsSectionProps) {
   return (
     <FocusedGoalSection
@@ -48,6 +50,9 @@ export function FocusedAdhocGoalsSection({
                 indentLevel={goal.indentLevel}
                 initiativeTitle={
                   goal.initiativeId ? initiativeTitleMap.get(goal.initiativeId) : undefined
+                }
+                initiativeColor={
+                  goal.initiativeId ? initiativeColorMap.get(goal.initiativeId) : undefined
                 }
               />
             ))}

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedGoalListItem.tsx
@@ -22,6 +22,7 @@ interface FocusedGoalListItemProps {
   indentLevel?: number;
   leadingIndicator?: React.ReactNode;
   initiativeTitle?: string;
+  initiativeColor?: string;
 }
 
 export function FocusedGoalListItem({
@@ -37,6 +38,7 @@ export function FocusedGoalListItem({
   indentLevel = 0,
   leadingIndicator,
   initiativeTitle,
+  initiativeColor,
 }: FocusedGoalListItemProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
@@ -64,10 +66,12 @@ export function FocusedGoalListItem({
         >
           {title}
         </button>
-        {initiativeTitle && (
+        {initiativeTitle && initiativeColor && (
           <InitiativeBadge
             title={initiativeTitle}
-            className={cn('flex-shrink-0', isComplete && 'bg-muted text-muted-foreground')}
+            color={initiativeColor}
+            muted={isComplete}
+            className="flex-shrink-0"
           />
         )}
       </li>

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedInitiativesSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedInitiativesSection.tsx
@@ -15,6 +15,10 @@ import {
 } from '@/components/molecules/focus/InitiativeFormDialog';
 import { InitiativesBrowseDialog } from '@/components/molecules/focus/InitiativesBrowseDialog';
 import { formatInitiativeDateRange, getInitiativeDateStatus } from '@/lib/date/initiative-dates';
+import {
+  buildInitiativeColorMap,
+  getInitiativeColorFromMap,
+} from '@/lib/initiative/initiative-color';
 import { filterInitiativesForFocusView } from '@/lib/initiative/initiative-focus-filters';
 import {
   initiativeStatusBadge,
@@ -43,10 +47,12 @@ function formatGoalCountLabel(counts: { total: number; open: number }): string |
 function InitiativeListRow({
   initiative,
   counts,
+  color,
   onView,
 }: {
   initiative: Doc<'initiatives'>;
   counts?: { total: number; open: number };
+  color: string;
   onView: () => void;
 }) {
   const status = getInitiativeDateStatus(initiative.startDate, initiative.endDate);
@@ -57,12 +63,19 @@ function InitiativeListRow({
     <li>
       <div className="flex items-start gap-1 rounded-md hover:bg-accent/50 transition-colors">
         <button type="button" onClick={onView} className="flex-1 min-w-0 text-left px-2 py-2">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{initiative.title}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {formatInitiativeDateRange(initiative.startDate, initiative.endDate)}
-              {goalCountLabel && <span>{` · ${goalCountLabel}`}</span>}
-            </p>
+          <div className="min-w-0 flex items-start gap-2">
+            <span
+              className="mt-1.5 flex-shrink-0 w-2 h-2 rounded-full"
+              style={{ backgroundColor: color }}
+              aria-hidden
+            />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">{initiative.title}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {formatInitiativeDateRange(initiative.startDate, initiative.endDate)}
+                {goalCountLabel && <span>{` · ${goalCountLabel}`}</span>}
+              </p>
+            </div>
           </div>
         </button>
         <span
@@ -99,6 +112,8 @@ export function FocusedInitiativesSection({
     () => sortInitiativesByStatusAndDate(focusInitiatives),
     [focusInitiatives]
   );
+
+  const colorMap = useMemo(() => buildInitiativeColorMap(initiatives), [initiatives]);
 
   const isFormOpen = isCreateOpen || editingInitiative !== null;
 
@@ -142,6 +157,7 @@ export function FocusedInitiativesSection({
                   key={initiative._id}
                   initiative={initiative}
                   counts={goalCounts?.[initiative._id]}
+                  color={getInitiativeColorFromMap(initiative._id, colorMap)}
                   onView={() => setViewingInitiative(initiative)}
                 />
               ))}

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedQuarterlyGoalsSection.tsx
@@ -12,6 +12,7 @@ interface FocusedQuarterlyGoalsSectionProps {
   onToggleComplete: (goalId: FocusedGoalItem['_id'], isComplete: boolean) => void;
   onAddGoal?: () => void;
   initiativeTitleMap: Map<Id<'initiatives'>, string>;
+  initiativeColorMap: Map<Id<'initiatives'>, string>;
 }
 
 export function FocusedQuarterlyGoalsSection({
@@ -19,6 +20,7 @@ export function FocusedQuarterlyGoalsSection({
   onToggleComplete,
   onAddGoal,
   initiativeTitleMap,
+  initiativeColorMap,
 }: FocusedQuarterlyGoalsSectionProps) {
   return (
     <FocusedGoalSection
@@ -66,6 +68,9 @@ export function FocusedQuarterlyGoalsSection({
                   leadingIndicator={indicator}
                   initiativeTitle={
                     goal.initiativeId ? initiativeTitleMap.get(goal.initiativeId) : undefined
+                  }
+                  initiativeColor={
+                    goal.initiativeId ? initiativeColorMap.get(goal.initiativeId) : undefined
                   }
                 />
               );

--- a/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
+++ b/apps/webapp/src/components/organisms/focus/focused-view/FocusedUrgentSection.tsx
@@ -11,12 +11,14 @@ interface FocusedUrgentSectionProps {
   goals: FocusedGoalItem[];
   onToggleComplete: (goalId: FocusedGoalItem['_id'], isComplete: boolean) => void;
   initiativeTitleMap: Map<Id<'initiatives'>, string>;
+  initiativeColorMap: Map<Id<'initiatives'>, string>;
 }
 
 export function FocusedUrgentSection({
   goals,
   onToggleComplete,
   initiativeTitleMap,
+  initiativeColorMap,
 }: FocusedUrgentSectionProps) {
   const incompleteCount = goals.filter((g) => !g.isComplete).length;
 
@@ -49,6 +51,9 @@ export function FocusedUrgentSection({
                 incompleteClassName="text-red-500 dark:text-red-400"
                 initiativeTitle={
                   goal.initiativeId ? initiativeTitleMap.get(goal.initiativeId) : undefined
+                }
+                initiativeColor={
+                  goal.initiativeId ? initiativeColorMap.get(goal.initiativeId) : undefined
                 }
               />
             ))}

--- a/apps/webapp/src/hooks/useInitiativeColorMap.ts
+++ b/apps/webapp/src/hooks/useInitiativeColorMap.ts
@@ -1,0 +1,10 @@
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+import { useMemo } from 'react';
+
+import { buildInitiativeColorMap } from '@/lib/initiative/initiative-color';
+
+export function useInitiativeColorMap(
+  initiatives: Doc<'initiatives'>[]
+): Map<Id<'initiatives'>, string> {
+  return useMemo(() => buildInitiativeColorMap(initiatives), [initiatives]);
+}

--- a/apps/webapp/src/lib/initiative/initiative-color.test.ts
+++ b/apps/webapp/src/lib/initiative/initiative-color.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildInitiativeColorMap,
+  getColorAtIndex,
+  getInitiativeColorFromMap,
+  INITIATIVE_COLOR_PALETTE,
+  INITIATIVE_PALETTE_MIN_SIZE,
+} from './initiative-color';
+
+describe('INITIATIVE_COLOR_PALETTE', () => {
+  it('has at least 30 colors', () => {
+    expect(INITIATIVE_COLOR_PALETTE.length).toBeGreaterThanOrEqual(INITIATIVE_PALETTE_MIN_SIZE);
+  });
+
+  it('has unique colors', () => {
+    const unique = new Set(INITIATIVE_COLOR_PALETTE);
+    expect(unique.size).toBe(INITIATIVE_COLOR_PALETTE.length);
+  });
+});
+
+describe('buildInitiativeColorMap', () => {
+  it('assigns unique colors to 5 initiatives', () => {
+    const initiatives = Array.from({ length: 5 }, (_, i) => ({
+      _id: `initiative-${i}` as unknown as never,
+      title: `Initiative ${i}`,
+      _creationTime: 1000 + i,
+    }));
+    const map = buildInitiativeColorMap(initiatives);
+    const colors = new Set(map.values());
+    expect(colors.size).toBe(5);
+  });
+
+  it('assigns unique colors to 30 initiatives', () => {
+    const initiatives = Array.from({ length: 30 }, (_, i) => ({
+      _id: `initiative-${i}` as unknown as never,
+      title: `Initiative ${i}`,
+      _creationTime: 1000 + i,
+    }));
+    const map = buildInitiativeColorMap(initiatives);
+    const colors = new Set(map.values());
+    expect(colors.size).toBe(30);
+  });
+
+  it('assigns colors in creation order (earlier _creationTime → lower palette index)', () => {
+    const initiatives = [
+      { _id: 'c' as unknown as never, title: 'C', _creationTime: 3000 },
+      { _id: 'a' as unknown as never, title: 'A', _creationTime: 1000 },
+      { _id: 'b' as unknown as never, title: 'B', _creationTime: 2000 },
+    ];
+    const map = buildInitiativeColorMap(initiatives);
+    expect(map.get('a' as unknown as never)).toBe(INITIATIVE_COLOR_PALETTE[0]);
+    expect(map.get('b' as unknown as never)).toBe(INITIATIVE_COLOR_PALETTE[1]);
+    expect(map.get('c' as unknown as never)).toBe(INITIATIVE_COLOR_PALETTE[2]);
+  });
+
+  it('uses title as tiebreaker when _creationTime is equal', () => {
+    const initiatives = [
+      { _id: 'b' as unknown as never, title: 'Beta', _creationTime: 1000 },
+      { _id: 'a' as unknown as never, title: 'Alpha', _creationTime: 1000 },
+    ];
+    const map = buildInitiativeColorMap(initiatives);
+    expect(map.get('a' as unknown as never)).toBe(INITIATIVE_COLOR_PALETTE[0]);
+    expect(map.get('b' as unknown as never)).toBe(INITIATIVE_COLOR_PALETTE[1]);
+  });
+});
+
+describe('getColorAtIndex', () => {
+  it('returns palette colors for indices within palette range', () => {
+    expect(getColorAtIndex(0)).toBe(INITIATIVE_COLOR_PALETTE[0]);
+    expect(getColorAtIndex(INITIATIVE_COLOR_PALETTE.length - 1)).toBe(
+      INITIATIVE_COLOR_PALETTE[INITIATIVE_COLOR_PALETTE.length - 1]
+    );
+  });
+
+  it('generates unique HSL colors beyond palette length', () => {
+    const colors = new Set(Array.from({ length: 35 }, (_, i) => getColorAtIndex(i)));
+    expect(colors.size).toBe(35);
+  });
+
+  it('is stable for the same index', () => {
+    expect(getColorAtIndex(5)).toBe(getColorAtIndex(5));
+    expect(getColorAtIndex(40)).toBe(getColorAtIndex(40));
+  });
+});
+
+describe('getInitiativeColorFromMap', () => {
+  it('returns the color for an initiative in the map', () => {
+    const map = new Map([['i1' as unknown as never, '#FF3B30']]);
+    expect(getInitiativeColorFromMap('i1' as unknown as never, map)).toBe('#FF3B30');
+  });
+
+  it('returns fallback color for missing initiative', () => {
+    const map = new Map();
+    expect(getInitiativeColorFromMap('unknown' as unknown as never, map)).toBe(
+      INITIATIVE_COLOR_PALETTE[0]
+    );
+  });
+});

--- a/apps/webapp/src/lib/initiative/initiative-color.ts
+++ b/apps/webapp/src/lib/initiative/initiative-color.ts
@@ -1,0 +1,89 @@
+import type { Doc, Id } from '@workspace/backend/convex/_generated/dataModel';
+
+/** Minimum palette size. */
+export const INITIATIVE_PALETTE_MIN_SIZE = 30;
+
+/** Curated distinct accessible colors — 30 hues with good contrast on light/dark themes. */
+export const INITIATIVE_COLOR_PALETTE: readonly string[] = [
+  '#FF3B30',
+  '#FF9500',
+  '#FFCC00',
+  '#34C759',
+  '#00C7BE',
+  '#30B0C7',
+  '#32ADE6',
+  '#007AFF',
+  '#5856D6',
+  '#AF52DE',
+  '#FF2D55',
+  '#A2845E',
+  '#E74C3C',
+  '#F39C12',
+  '#2ECC71',
+  '#1ABC9C',
+  '#3498DB',
+  '#9B59B6',
+  '#E91E63',
+  '#795548',
+  '#FF7043',
+  '#66BB6A',
+  '#26C6DA',
+  '#42A5F5',
+  '#AB47BC',
+  '#EC407A',
+  '#8D6E63',
+  '#78909C',
+  '#7CB342',
+  '#00ACC1',
+] as const;
+
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+/** Returns a unique color at sequential index; uses palette for 0..palette.length-1, generates HSL golden-angle hues beyond. */
+export function getColorAtIndex(index: number): string {
+  if (index < INITIATIVE_COLOR_PALETTE.length) {
+    return INITIATIVE_COLOR_PALETTE[index];
+  }
+  const hue = (index * 137.508) % 360;
+  return hslToHex(hue, 65, 48);
+}
+
+function sortInitiativesForColorAllocation(
+  initiatives: Pick<Doc<'initiatives'>, '_id' | 'title' | '_creationTime'>[]
+): Pick<Doc<'initiatives'>, '_id' | 'title' | '_creationTime'>[] {
+  return [...initiatives].sort(
+    (a, b) => a._creationTime - b._creationTime || a.title.localeCompare(b.title)
+  );
+}
+
+/** Assigns unique colors sequentially by creation order. */
+export function buildInitiativeColorMap(
+  initiatives: Pick<Doc<'initiatives'>, '_id' | 'title' | '_creationTime'>[]
+): Map<Id<'initiatives'>, string> {
+  const sorted = sortInitiativesForColorAllocation(initiatives);
+  const map = new Map<Id<'initiatives'>, string>();
+  sorted.forEach((initiative, index) => {
+    map.set(initiative._id, getColorAtIndex(index));
+  });
+  return map;
+}
+
+/** Looks up color from map with first-palette fallback. */
+export function getInitiativeColorFromMap(
+  initiativeId: Id<'initiatives'>,
+  colorMap: Map<Id<'initiatives'>, string>
+): string {
+  return colorMap.get(initiativeId) ?? INITIATIVE_COLOR_PALETTE[0];
+}


### PR DESCRIPTION
## Summary

Replace per-title hash coloring with creation-order sequential unique color map. Palette expanded to 30 accessible colors with HSL golden-angle overflow beyond palette. Color is never stored on schema — computed client-side only.

## Changes

### Core utility (`initiative-color.ts`)
- **`INITIATIVE_COLOR_PALETTE`**: 30 curated colors (was 12)
- **`buildInitiativeColorMap`**: assigns colors by `_creationTime` ASC, `title` ASC tiebreaker
- **`getColorAtIndex`**: palette lookup for 0..29, HSL golden-angle overflow beyond
- **`getInitiativeColorFromMap`**: map lookup with fallback
- Removed: `getInitiativeColorFromTitle`, `hashStringToIndex`, `normalizeInitiativeTitleForColor`

### New hook
- **`useInitiativeColorMap`**: mirrors `useInitiativeTitleMap` pattern

### Component wiring
- **`InitiativeBadge`**: required `color` prop (was title-based hash)
- **`InitiativeBadgeForGoal`**: resolves color via `useInitiativeColorMap`
- **`InitiativeListItemMeta`**: required `color` prop
- **`InitiativeSelector`**, **`InitiativesBrowseDialog`**: build color map, pass to list items
- **`FocusedInitiativesSection`**: color map for row dots
- **`FocusedUrgentSection`**, **`FocusedQuarterlyGoalsSection`**, **`FocusedAdhocGoalsSection`**: accept `initiativeColorMap`, pass to `FocusedGoalListItem`
- **`FocusedGoalListItem`**: passes `initiativeColor` to `InitiativeBadge`

## Test Plan
1. **Unit tests**: 11 tests covering palette size (>=30), uniqueness, creation-order assignment, title tiebreaker, HSL overflow (35 initiatives → 35 unique colors), stability, fallback
2. **Typecheck**: only pre-existing `@tiptap/extension-underline` error (unrelated)
3. **Full tests**: 258 passed, 35 files

## File changed
14 files modified/created