### PR TITLE
feat(goal-details): colorize selected initiative in modal

### DIFF
--- a/apps/webapp/src/components/atoms/InitiativeSelector.test.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.test.tsx
@@ -64,4 +64,18 @@ describe('InitiativeSelector', () => {
     expect(host.contains(search)).toBe(true);
     expect(container.contains(search)).toBe(true);
   });
+
+  it('shows a color dot for the selected initiative in the trigger', () => {
+    render(
+      <InitiativeSelector
+        initiatives={initiatives}
+        selectedInitiativeId="initiatives:alpha"
+        onInitiativeChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('Q1 Launch');
+    const colorDot = screen.getByRole('combobox').querySelector('[aria-hidden="true"]');
+    expect(colorDot).toHaveStyle({ backgroundColor: '#FF3B30' });
+  });
 });

--- a/apps/webapp/src/components/atoms/InitiativeSelector.tsx
+++ b/apps/webapp/src/components/atoms/InitiativeSelector.tsx
@@ -75,8 +75,21 @@ export function InitiativeSelector({
             disabled={disabled}
             className={cn('w-full justify-between font-normal', className)}
           >
-            <span className="truncate">
-              {selectedInitiative ? selectedInitiative.title : placeholder}
+            <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-left">
+              {selectedInitiative ? (
+                <>
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: getInitiativeColorFromMap(selectedInitiative._id, colorMap),
+                    }}
+                    aria-hidden
+                  />
+                  <span className="truncate">{selectedInitiative.title}</span>
+                </>
+              ) : (
+                <span className="truncate text-muted-foreground">{placeholder}</span>
+              )}
             </span>
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>


### PR DESCRIPTION
## Summary
- Show the sequential palette color dot next to the selected initiative title in `InitiativeSelector`
- Applies to the goal details modal (`GoalInitiativeField`) and any other selector usages

## Test plan
- [x] Unit test: selected initiative trigger shows color dot with first palette color
- [ ] Open goal details modal with an initiative tagged — verify colored dot appears in the Initiative field
- [ ] Open initiative dropdown — verify list items still show colors as before
- [ ] Clear initiative selection — verify placeholder shows without dot


Made with [Cursor](https://cursor.com)